### PR TITLE
README update and removed obsolete commands in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,22 +45,7 @@ EV := test -f director/env.sh && source director/env.sh || source director/env-e
 # Shortcut to run a Django manage.py task in the virtual environment; used below
 DJ ?= $(VE) $(EV) python3 director/manage.py
 
-# Install necessary system packages
-director-setup: director-setup-dirs
-	# Install necessary system dependencies etc
-ifeq ($(OS),Linux)
-	sudo apt-get install libev-dev
-endif
-ifeq ($(OS),Darwin)
-	brew install libev
-endif
 
-director-setup-dirs:
-	# Setup directories
-	mkdir -p secrets
-	ln -sfT ../secrets director/secrets
-	mkdir -p storage
-	ln -sfT ../storage director/storage
 
 # Setup virtual environment
 director/venv: director/requirements.txt

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Stencila is an open source platform for authoring, collaborating on, and sharing
 
 ## Contribute
 
-We are always keen to get comments and suggestions for ways to improve the Stencila Hub. Chat with us in the [stencila/stencila room](https://gitter.im/stencila/stencila) on Gitter or using the in-app intercom (if you have a user account). 
+We are always keen to get comments and suggestions for ways to improve the Stencila Hub. Chat with us in the [stencila/stencila room](https://gitter.im/stencila/stencila) on Gitter or using the in-app intercom (if you have a user account).
 
 If you have specific suggestions or have found a bug, please [create an issue](https://github.com/stencila/hub/issues/new). If you have any issue related to security, please send us an email at security@stenci.la, rather than create a Github issue.
 
@@ -14,10 +14,11 @@ Code contributions will be gratefully received! Please send use a pull request.
 
 ## Develop
 
+Stencila Hub consists of three roles: `director`, `editor` and `router`. Each of these roles can be set up for development separately. That is, you can contribute to the
+Hub getting these roles set up and run independently. You should develop in your local environment rather than in the Docker container, which can be set up for each of these
+	roles) because this way you will be able to preview the changes you are making in the source code.
 
-### Setup directories
-
-Two directories are shared amongst roles: `storage` (for sharing project content across roles) and `secrets` (for sharing any secrets across roles). In production, these directories will usually be mounted as volumes (e.g. Kubernetes volumes). To keep [development and production environments as consistent as possible](https://12factor.net/dev-prod-parity), during development we simulate mounting these directories into each role by creating symlinks to a top level directory. See `make director-setup` and `make editor-setup` for doing this. If you prefer not to take this approach, you can override where `director` looks for these set the environment variables `STORAGE_DIR` and `SECRETS_DIR`.
+The Docker containers (`stencila/hub-director`, `stencila/hub-editor`, `stencila/hub-router`) are used for deployment.
 
 ### Run `director`
 
@@ -27,11 +28,23 @@ To run the `director` locally:
 make director-run
 ```
 
-Or, to run the `director` in Docker:
+This will setup virtual environment installing all required packages. **Note** You need to have `python3` and `pip3` installed on your machine.
+
+When you are running the `director` for the first time, you will need to set up the database for Django. For the development we use `sqlite3`. In oder to get that done:
+
+```bash
+make director-create-devdb
+```
+You should now be set up for development and access the development server at `http://127.0.0.1:8000/`
+
+To run the `director` in Docker:
 
 ```bash
 make director-build director-rundocker
 ```
+
+**Note** This will first build the Docker file (`hub-director`) and then run director in that Docker container. If you make changes to the source code after you build the,
+Docker file they will not be reflected in the container. You will have to rebuild it. Hence, it is recommended that you develop the Hub in your local environment.
 
 ### Run `editor`
 
@@ -55,4 +68,4 @@ The `router` is configured to listen on port 3000 (to avoid clashing with other 
 make router-build router-rundocker
 ```
 
-Now, you should be able to access the the Hub at http://localhost:3000. 
+Now, you should be able to access the the Hub at http://localhost:3000.


### PR DESCRIPTION
1. Updated README with more detailed instructions how to set up and run `director`

2. Removed obsolete information about setting up folders for shared secrets (between the roles).

3. Removed obsolete commands in Makefile:
  * not using `bjoern` (replaced by `gunicorn`) any more so `libev` installation is not needed
  * shared secrets folders etc not needed any more (see 2 above)