### PR TITLE
Fixed small bug in permissions for viewing accounts

### DIFF
--- a/director/accounts/templates/accounts/_account_header.html
+++ b/director/accounts/templates/accounts/_account_header.html
@@ -15,7 +15,7 @@
   </div>
 </div>
 
-{% if account_permissions|permissions_contain:'administer' %}
+{% if account_permissions|permissions_contain:'administer' == True %}
 <div class="tabs is-toggle is-fullwidth">
   <ul>
     {% if tab == "profile" %}


### PR DESCRIPTION
Looks like it needs to be very explicit in the templating "language":

```
{% if account_permissions|permissions_contain:'administer' == True %}
```

The below fails when accessing Settings:
```
{% if account_permissions|permissions_contain:'administer' 
```