### PR TITLE
feat: Uploads now go direct to disk and FileSources are redundant.

### DIFF
--- a/director/projects/disk_file_facade.py
+++ b/director/projects/disk_file_facade.py
@@ -1,0 +1,74 @@
+import shutil
+import typing
+
+from projects.project_models import Project
+from projects.source_operations import generate_project_storage_directory, relative_path_join, utf8_path_exists, \
+    utf8_makedirs, to_utf8, utf8_isdir, utf8_unlink, utf8_path_join, utf8_basename, utf8_rename, utf8_dirname
+
+
+class DiskFileFacade(object):
+    project: Project
+    project_storage_directory: str
+
+    def __init__(self, project_storage_root: str, project: Project) -> None:
+        self.project = project
+        self.project_storage_directory = generate_project_storage_directory(project_storage_root, project)
+
+    def generate_full_file_path(self, relative_path: str) -> str:
+        return relative_path_join(self.project_storage_directory, relative_path)
+
+    def create_directory(self, relative_path: str) -> None:
+        full_path = self.generate_full_file_path(relative_path)
+        utf8_makedirs(full_path, exist_ok=True)
+
+    def create_file(self, relative_path: str) -> None:
+        full_path = self.generate_full_file_path(relative_path)
+        if utf8_path_exists(full_path):
+            raise OSError('Can not create project file at {} as it already exists'.format(full_path))
+
+        utf8_makedirs(utf8_dirname(full_path), exist_ok=True)
+
+        with open(full_path, 'a'):
+            pass
+
+    def remove_item(self, relative_path: str) -> None:
+        full_path = self.generate_full_file_path(relative_path)
+        if not utf8_path_exists(full_path):
+            raise OSError('Can not remove {} as it does not exist'.format(full_path))
+
+        if utf8_isdir(full_path):
+            shutil.rmtree(to_utf8(full_path))
+        else:
+            utf8_unlink(full_path)
+
+    def write_file_content(self, relative_path: str, content: typing.Union[str, bytes]) -> None:
+        if isinstance(content, str):
+            mode = 'w'
+        else:
+            mode = 'wb'
+
+        with open(self.generate_full_file_path(relative_path), mode) as f:
+            f.write(content)
+
+    def read_file_content(self, relative_path: str) -> bytes:
+        with open(self.generate_full_file_path(relative_path), 'rb') as f:
+            return f.read()
+
+    def item_exists(self, relative_path: str) -> bool:
+        return utf8_path_exists(self.generate_full_file_path(relative_path))
+
+    def move_file(self, current_relative_path: str, new_relative_path: str) -> None:
+        current_path = self.generate_full_file_path(current_relative_path)
+        new_path = self.generate_full_file_path(new_relative_path)
+
+        if utf8_isdir(new_path):
+            # path moving to is a directory so actually move inside the path
+            filename = utf8_basename(current_path)
+            new_path = utf8_path_join(new_path, filename)
+
+        if utf8_path_exists(new_path):
+            raise OSError(
+                'Can not move {} to {} as target file exists.'.format(current_relative_path, new_relative_path))
+
+        utf8_makedirs(utf8_dirname(new_path), exist_ok=True)
+        utf8_rename(current_path, new_path)

--- a/director/projects/disk_file_facade.py
+++ b/director/projects/disk_file_facade.py
@@ -42,6 +42,10 @@ class DiskFileFacade(object):
             utf8_unlink(full_path)
 
     def write_file_content(self, relative_path: str, content: typing.Union[str, bytes]) -> None:
+        if not self.item_exists(relative_path):
+            # takes care of creating the directories etc, even though it is an extra open call
+            self.create_file(relative_path)
+
         if isinstance(content, str):
             mode = 'w'
         else:

--- a/director/projects/management/commands/pull_all_projects.py
+++ b/director/projects/management/commands/pull_all_projects.py
@@ -1,0 +1,28 @@
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.http import HttpRequest
+
+from projects.project_models import Project
+from projects.project_puller import ProjectSourcePuller
+from projects.source_models import LinkedSourceAuthentication
+
+
+class Command(BaseCommand):
+    help = 'Pulls all FileSources for all projects.'
+
+    def handle(self, *args, **options):
+        if not settings.STENCILA_PROJECT_STORAGE_DIRECTORY:
+            raise RuntimeError('STENCILA_PROJECT_STORAGE_DIRECTORY setting must be set to pull Project files.')
+
+        request = HttpRequest()
+        # django messages need a request to work with, although they are only used if there is an error with a
+        # GitHubSource which we aren't working with so this stub object is OK
+
+        lsa = LinkedSourceAuthentication(None)
+        # Again, the Puller is not dealing with GitHubSources so it is OK if this is a stub
+
+        for project in Project.objects.all():
+            print('Pulling Project {}'.format(project.id))
+            puller = ProjectSourcePuller(project, settings.STENCILA_PROJECT_STORAGE_DIRECTORY, lsa, request)
+            puller.pull(True)
+            print('Finished pulling Project {}'.format(project.id))

--- a/director/projects/project_puller.py
+++ b/director/projects/project_puller.py
@@ -36,13 +36,13 @@ class ProjectSourcePuller(object):
         """Combine the `target_directory` and project ID."""
         return generate_project_storage_directory(self.target_directory, self.project)
 
-    def pull(self) -> None:
+    def pull(self, only_file_sources: bool = False) -> None:
         """Perform the pull of the project files."""
         event = ProjectEvent(event_type=ProjectEventType.SOURCE_PULL.name, project=self.project)
         event.save()
         utf8_makedirs(self.project_directory, exist_ok=True)
         try:
-            self.pull_directory()
+            self.pull_directory(only_file_sources=only_file_sources)
             event.success = True
         except Exception as e:
             event.message = str(e)
@@ -52,13 +52,13 @@ class ProjectSourcePuller(object):
             event.finished = timezone.now()
             event.save()
 
-    def pull_directory(self, sub_directory: typing.Optional[str] = None) -> None:
+    def pull_directory(self, sub_directory: typing.Optional[str] = None, only_file_sources: bool = True) -> None:
         """
         Pull one 'virtual' directory to disk.
 
         Will create directories and files in `sub_directory`, then recurse into directories to repeat the pull.
         """
-        dir_list = list_project_virtual_directory(self.project, sub_directory, self.authentication)
+        dir_list = list_project_virtual_directory(self.project, sub_directory, self.authentication, only_file_sources)
 
         working_directory = sub_directory or ''
         fs_working_directory = utf8_path_join(self.project_directory, working_directory)

--- a/director/projects/project_views.py
+++ b/director/projects/project_views.py
@@ -236,10 +236,6 @@ class ProjectOverviewView(ProjectPermissionsMixin, DetailView):
         return context
 
 
-def get_linked_sources_for_project(project: Project) -> typing.Iterable[Source]:
-    return filter(lambda s: not isinstance(s, FileSource), project.sources.all())
-
-
 class ProjectFilesView(ProjectPermissionsMixin, View):
     project_permission_required = ProjectPermissionType.VIEW
 
@@ -265,7 +261,7 @@ class ProjectFilesView(ProjectPermissionsMixin, View):
             {
                 'session_check_path': session_check_path,
                 'session_start_path': session_start_path,
-                'linked_sources': list(get_linked_sources_for_project(self.project)),
+                'linked_sources': list(self.project.sources.not_instance_of(FileSource)),
                 'current_directory': path,
                 'breadcrumbs': path_entry_iterator(path),
                 'items': directory_items,

--- a/director/projects/source_edit.py
+++ b/director/projects/source_edit.py
@@ -8,7 +8,7 @@ from django.http import HttpRequest
 from github import GithubException
 
 from lib.github_facade import GitHubFacade
-from projects.source_models import Source, GithubSource, FileSource, LinkedSourceAuthentication, DiskFileSource
+from projects.source_models import Source, GithubSource, FileSource, LinkedSourceAuthentication, DiskSource
 from projects.source_operations import strip_directory, utf8_path_join
 
 
@@ -16,18 +16,18 @@ class SourceEditContext(typing.NamedTuple):
     path: str
     extension: str
     content: typing.Union[str, BytesIO]
-    source: typing.Union[Source, DiskFileSource]
+    source: typing.Union[Source, DiskSource]
     editable: bool
     supports_commit_message: bool
 
 
 class SourceContentFacade(object):
-    source: typing.Union[Source, DiskFileSource]
+    source: typing.Union[Source, DiskSource]
     request: HttpRequest
     authentication: typing.Optional[LinkedSourceAuthentication]
     file_path: str
 
-    def __init__(self, source: typing.Union[Source, DiskFileSource],
+    def __init__(self, source: typing.Union[Source, DiskSource],
                  authentication: typing.Optional[LinkedSourceAuthentication],
                  request: HttpRequest, file_path: str) -> None:
         self.source = source
@@ -40,7 +40,7 @@ class SourceContentFacade(object):
             return self.get_file_source_content()
         elif isinstance(self.source, GithubSource):
             return self.get_github_source_content()
-        elif isinstance(self.source, DiskFileSource):
+        elif isinstance(self.source, DiskSource):
             with open(self.file_path, 'r') as f:
                 return f.read()
         else:
@@ -51,7 +51,7 @@ class SourceContentFacade(object):
             return self.get_file_source_binary_content()
         elif isinstance(self.source, GithubSource):
             return self.get_github_source_binary_content()
-        elif isinstance(self.source, DiskFileSource):
+        elif isinstance(self.source, DiskSource):
             with open(self.file_path, 'rb') as f:
                 return BytesIO(f.read())
         else:
@@ -89,7 +89,7 @@ class SourceContentFacade(object):
         elif isinstance(self.source, GithubSource):
             editable = self.authentication.github_token is not None
             supports_commit_message = True
-        elif isinstance(self.source, DiskFileSource):
+        elif isinstance(self.source, DiskSource):
             editable = True
         else:
             raise TypeError("Don't know how to get EditContext for source type '{}'".format(type(self.source)))
@@ -103,7 +103,7 @@ class SourceContentFacade(object):
             return self.update_file_source_content(content)
         elif isinstance(self.source, GithubSource):
             return self.update_github_source_content(content, commit_message)
-        elif isinstance(self.source, DiskFileSource):
+        elif isinstance(self.source, DiskSource):
             with open(self.file_path, 'w') as f:
                 f.write(content)
             return True

--- a/director/projects/source_item_models.py
+++ b/director/projects/source_item_models.py
@@ -3,7 +3,7 @@ import functools
 import typing
 from datetime import datetime
 
-from projects.source_models import MimeTypeFromPathMixin, Source, DiskFileSource
+from projects.source_models import MimeTypeFromPathMixin, Source, DiskSource
 
 
 class DirectoryEntryType(enum.Enum):
@@ -32,11 +32,11 @@ class DirectoryListEntry(MimeTypeFromPathMixin):
     name: str
     path: str
     type: DirectoryEntryType
-    source: typing.Union[Source, DiskFileSource]
+    source: typing.Union[Source, DiskSource]
     _modification_date: typing.Optional[datetime]
 
     def __init__(self, name: typing.Union[str, bytes], path: typing.Union[str, bytes], entry_type: DirectoryEntryType,
-                 source: typing.Union[Source, DiskFileSource],
+                 source: typing.Union[Source, DiskSource],
                  modification_date: typing.Optional[datetime] = None) -> None:
         self.name = name if isinstance(name, str) else name.decode('utf8')
         self.path = path if isinstance(path, str) else path.decode('utf8')

--- a/director/projects/source_models.py
+++ b/director/projects/source_models.py
@@ -20,7 +20,7 @@ class MimeTypeFromPathMixin(object):
         return mimetype or 'Unknown'
 
 
-class DiskFileSource(object):
+class DiskSource(object):
     """Not a Source that is stored in the database but used in directory listing for files that are already on disk."""
 
     type = 'disk'

--- a/director/projects/source_operations.py
+++ b/director/projects/source_operations.py
@@ -11,7 +11,7 @@ from lib.github_facade import GitHubFacade
 from projects.project_models import Project
 from projects.source_item_models import PathEntry, DirectoryListEntry, DirectoryEntryType
 
-from projects.source_models import Source, FileSource, GithubSource, LinkedSourceAuthentication, DiskFileSource
+from projects.source_models import Source, FileSource, GithubSource, LinkedSourceAuthentication, DiskSource
 
 PathType = typing.Union[str, bytes]
 
@@ -239,7 +239,7 @@ def os_dir_entry_to_directory_list_entry(virtual_path: str, dir_entry: os.DirEnt
 
     return DirectoryListEntry(dir_entry.name.decode('utf8'), utf8_path_join(virtual_path, dir_entry.name),
                               DirectoryEntryType.DIRECTORY if dir_entry.is_dir() else DirectoryEntryType.FILE,
-                              DiskFileSource(), datetime.datetime.fromtimestamp(s.st_mtime))
+                              DiskSource(), datetime.datetime.fromtimestamp(s.st_mtime))
 
 
 def list_project_filesystem_directory(project_storage_root: str, project: Project,

--- a/director/projects/source_views.py
+++ b/director/projects/source_views.py
@@ -16,7 +16,7 @@ from projects.disk_file_facade import DiskFileFacade
 from projects.permission_models import ProjectPermissionType
 from projects.project_views import ProjectPermissionsMixin
 from projects.source_edit import SourceEditContext, SourceContentFacade
-from projects.source_models import LinkedSourceAuthentication, DiskFileSource
+from projects.source_models import LinkedSourceAuthentication, DiskSource
 from projects.source_operations import strip_directory, get_filesystem_project_path, utf8_path_join
 from .models import Project, DropboxSource, GithubSource
 from .source_forms import GithubSourceForm, DiskFileSourceForm
@@ -212,7 +212,7 @@ class DiskFileSourceOpenView(SourceOpenView):
     def get_content_facade(self, request: HttpRequest, project_pk: int, pk: int, path: str):
         fs_path = get_filesystem_project_path(settings.STENCILA_PROJECT_STORAGE_DIRECTORY,
                                               self.get_project(request.user, project_pk), path)
-        return SourceContentFacade(DiskFileSource(), None, request, fs_path)
+        return SourceContentFacade(DiskSource(), None, request, fs_path)
 
     def get(self, request: HttpRequest, project_pk: int, path: str) -> HttpResponse:  # type: ignore
         content_facade = self.get_content_facade(request, project_pk, -1, path)

--- a/director/projects/templates/projects/filesource_create.html
+++ b/director/projects/templates/projects/filesource_create.html
@@ -6,7 +6,7 @@
 {% block content %}
 <div class="section">
     <h1 class="title is-4">{{ project }}: Create file</h1>
-    <h3 class="subtitle is-5">File will be created in directory <em>/{{ current_directory }}</em></h3>
+    <h3 class="subtitle is-5">File will be created in directory <em>{{ current_directory }}</em></h3>
     {% crispy form %}
 </div>
 {% endblock %}

--- a/director/projects/templates/projects/project_files.html
+++ b/director/projects/templates/projects/project_files.html
@@ -101,8 +101,8 @@
                 {% endif %}
                 <a class="button is-primary" style="margin-left: 0.5em" @click="pullFiles" id="project-pull-button">
                     <span class="icon is-small"><i class="fas fa-file-export"></i></span>
-                    <span v-if="!pullInProgress">Pull Files</span>
-                    <span v-if="pullInProgress">Pulling Files&hellip;</span>
+                    <span v-if="!pullInProgress">Pull Linked Sources</span>
+                    <span v-if="pullInProgress">Pulling Linked Sources&hellip;</span>
                 </a>
             </div>
         </div>
@@ -175,8 +175,8 @@
                                         data-editor-url="{% source_path project directory_entry %}">Code editor
                                 </option>
                                 {% if directory_entry.name == 'manifest.xml' %}
-                                    <option data-path="{{ directory_entry.path|escape }}" value="desktop">Stencila
-                                        Desktop
+                                    <option data-path="{{ directory_entry.path|escape }}" value="desktop">
+                                        Stencila Desktop
                                     </option>
                                 {% endif %}
                             </select>
@@ -187,13 +187,15 @@
                 <td>{{ directory_entry.modification_date|naturaltime }}</td>
 
                 <td>
-                    {% if directory_entry.source.type == 'filesource' and not directory_entry.is_directory %}
-                        <a class="icon"
-                           href="{% url 'source_update' project.pk directory_entry.source.id %}?from={{ current_directory }}">
-                            <i class="fas fa-cog"></i>
-                        </a>
+                    {% if directory_entry.source.type == 'disk' %}
+                        {% if not directory_entry.is_directory %}
+                            <a class="icon"
+                               href="{% url 'file_source_update' project.pk directory_entry.path %}?from={{ current_directory }}">
+                                <i class="fas fa-cog"></i>
+                            </a>
+                        {% endif %}
                         <a class="icon has-text-danger"
-                           href="{% url 'source_delete' project.pk directory_entry.source.id %}?from={{ current_directory }}">
+                           href="{% url 'file_source_delete' project.pk directory_entry.path %}?from={{ current_directory }}">
                             <i class="fas fa-trash"></i>
                         </a>
                     {% endif %}

--- a/director/projects/templates/projects/project_overview.html
+++ b/director/projects/templates/projects/project_overview.html
@@ -44,8 +44,8 @@
                 <div class="row is-top-padding">
                     <button class="button is-rounded is-fullwidth" type="button" @click="checkoutFiles">
                         <span class="icon is-small"><i class="fas fa-file-export"></i></span>
-                        <span v-if="!checkoutInProgress">Pull Files</span>
-                        <span v-if="checkoutInProgress">Pulling Files&hellip;</span>
+                        <span v-if="!checkoutInProgress">Pull Linked Sources</span>
+                        <span v-if="checkoutInProgress">Pulling Linked Sources<&hellip;</span>
                     </button>
                 </div>
             </div>

--- a/director/projects/templates/projects/source_update.html
+++ b/director/projects/templates/projects/source_update.html
@@ -5,6 +5,8 @@
 
 {% block content %}
 <div class="section">
+    <h1 class="title is-4">{{ project }}: Modify File</h1>
+    <h3 class="subtitle is-5">Current Path <em>{{ current_path }}</em></h3>
     <form method="post">
         {% csrf_token %}
         {{ form | crispy }}

--- a/director/projects/templatetags/source_extras.py
+++ b/director/projects/templatetags/source_extras.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 
 from projects.project_models import Project
 from projects.source_item_models import DirectoryListEntry, DirectoryEntryType
-from projects.source_models import DiskFileSource
+from projects.source_models import DiskSource
 
 register = template.Library()
 
@@ -18,7 +18,7 @@ def source_path(project: Project, directory_entry: DirectoryListEntry):
         return reverse(view_name, args=view_args)
 
     if directory_entry.type == DirectoryEntryType.FILE:
-        if isinstance(directory_entry.source, DiskFileSource):
+        if isinstance(directory_entry.source, DiskSource):
             return reverse('real_file_source_open', args=(project.pk, directory_entry.path))
         else:
             return reverse('file_source_open', args=(project.pk, directory_entry.source.pk, directory_entry.path))

--- a/director/projects/urls.py
+++ b/director/projects/urls.py
@@ -8,8 +8,8 @@ from projects.project_views import (ProjectListView, ProjectCreateView, ProjectO
                                     ProjectArchiveDownloadView, ProjectDeleteView, ProjectPullView, ProjectArchiveView,
                                     ProjectNamedArchiveDownloadView, ProjectRefreshView)
 from projects.source_views import (FileSourceCreateView, FileSourceUploadView, DropboxSourceCreateView,
-                                   GithubSourceCreateView, FileSourceOpenView, FileSourceUpdateView,
-                                   FileSourceDeleteView, DiskFileSourceOpenView)
+                                   GithubSourceCreateView, SourceOpenView, DiskFileSourceUpdateView,
+                                   DiskFileSourceDeleteView, DiskFileSourceOpenView)
 
 urlpatterns = [
     # Generic views
@@ -29,10 +29,10 @@ urlpatterns = [
     path('<int:pk>/files/link/dropbox', DropboxSourceCreateView.as_view(), name='dropboxsource_create'),
     path('<int:pk>/files/link/github', GithubSourceCreateView.as_view(), name='githubsource_create'),
 
-    path('<int:project_pk>/files/<int:pk>/open/<path:path>', FileSourceOpenView.as_view(), name='file_source_open'),
+    path('<int:project_pk>/files/<int:pk>/open/<path:path>', SourceOpenView.as_view(), name='file_source_open'),
     path('<int:project_pk>/files/open/<path:path>', DiskFileSourceOpenView.as_view(), name='real_file_source_open'),
-    path('<int:project_pk>/files/<int:pk>/update', FileSourceUpdateView.as_view(), name='source_update'),
-    path('<int:project_pk>/files/<int:pk>/delete', FileSourceDeleteView.as_view(), name='source_delete'),
+    path('<int:pk>/files/update/<path:path>', DiskFileSourceUpdateView.as_view(), name='file_source_update'),
+    path('<int:pk>/files/delete/<path:path>', DiskFileSourceDeleteView.as_view(), name='file_source_delete'),
 
     path('<int:pk>/activity/', ProjectActivityView.as_view(), name='project_activity'),
     path('<int:pk>/sharing/', ProjectSharingView.as_view(), name='project_sharing'),


### PR DESCRIPTION
@nokome Appreciate this is a big change and you're quite busy but it would be good if you just gave it a once over.

There is no way to create new `FileSource`s except for in the ProjectRefresh which will soon be deprecated.

I have created a Django command that needs to be run after this code is deployed to pull every project's virtual files to disk.