### PR TITLE
Detecting if user is using IE and warning that it's not be supported

### DIFF
--- a/director/assets/js/ie-detect.js
+++ b/director/assets/js/ie-detect.js
@@ -1,17 +1,11 @@
 var sBrowser, sUsrAg = navigator.userAgent;
 
-Vue.component('modal', {
-    template: '#modal-template'
-  })
+
 
 if (sUsrAg.indexOf("MSIE") > -1) {
   sBrowser = "Microsoft Internet Explorer";
-  new Vue({
-    el: '#app',
-   showModal: true
-    }
-  ) 
+  
 
-//  document.write("You are using " + sBrowser + ". Unfortunately, Stencila Hub does not support this browser. Please use Chrome, Safari or Firefox."); 
+  alert("You are using " + sBrowser + ". Unfortunately, Stencila Hub does not support this browser. Please use Chrome, Safari or Firefox."); 
 }
 

--- a/director/assets/js/ie-detect.js
+++ b/director/assets/js/ie-detect.js
@@ -1,0 +1,17 @@
+var sBrowser, sUsrAg = navigator.userAgent;
+
+Vue.component('modal', {
+    template: '#modal-template'
+  })
+
+if (sUsrAg.indexOf("MSIE") > -1) {
+  sBrowser = "Microsoft Internet Explorer";
+  new Vue({
+    el: '#app',
+   showModal: true
+    }
+  ) 
+
+//  document.write("You are using " + sBrowser + ". Unfortunately, Stencila Hub does not support this browser. Please use Chrome, Safari or Firefox."); 
+}
+

--- a/director/templates/base.html
+++ b/director/templates/base.html
@@ -23,7 +23,7 @@
 
         <script type="text/javascript" src="{% static 'js/vue.min.js' %}"></script>
         <script type="text/javascript" src="{% static 'js/buefy.min.js' %}"></script>
-
+        <script type="text/javascript" src="{% static 'js/ie-detect.js' %}"></script>
         <script>
             Vue.use(Buefy.default)
         </script>


### PR DESCRIPTION
The detection works. But the `alert` is a really ugly and annoying (it pops up every time page is reloaded or a new page is opened in the Hub) way of informing the user.
GH has a nice ribbon at the top when you try to use IE with it but I am (yet) not sure how to add it. Comments welcome :grin: 