### PR TITLE
Hub UI tweaks: section--inner spacing, column sizes, button/anchor alignment, box usage

### DIFF
--- a/director/accounts/templates/accounts/account_list.html
+++ b/director/accounts/templates/accounts/account_list.html
@@ -2,30 +2,31 @@
 {% block title %}Account {{account.pk}} : Teams{% endblock %}
 {% block content %}
 
-<div class="level-right">
-    <p class="level-item">
-        <a class="button is-success" href="{% url 'account_create' %}">
-            <span class="icon"><i class="fas fa-plus"></i></span>
-            <span>New</span>
-        </a>
-    </p>
-</div>
-    <div class="section">
-        {% for account_role in object_list %}
-        <div class="column">
-            <div class="card">
-                <div class="card-content">
-                    <a href="{% url 'account_profile' account_role.account.id %}" title="Open">
-                        <span>{{ account_role.account }}</span>
-                    </a>
-                    <span class="is-pulled-right">{{ account_role.role }}</span>
-                </div>
-            </div>
+<div class="level">
+    <div class="level-left">
+        <div class="level-item">
+            <p class="title is-2">Accounts</p>
         </div>
-        {% empty %}
-        <div class="column">
-            <div class="notification is-warning">You are not a member of any accounts</div>
-        </div>
-        {% endfor %}
     </div>
+    <div class="level-right">
+        <p class="level-item">
+            <a class="button is-outlined is-primary is-rounded call-to-action" href="{% url 'account_create' %}">
+                <span class="icon"><i class="fas fa-plus"></i></span>
+                <span>New Account</span>
+            </a>
+        </p>
+    </div>
+</div>
+<div class="section section--inner">
+    {% for account_role in object_list %}
+        <a class="box" href="{% url 'account_profile' account_role.account.id %}" title="Open">
+            <span>{{ account_role.account }}</span>
+            <span class="is-pulled-right">{{ account_role.role }}</span>
+        </a>
+    {% empty %}
+    <div class="column">
+        <div class="notification is-warning">You are not a member of any accounts</div>
+    </div>
+    {% endfor %}
+</div>
 {% endblock %}

--- a/director/assets/css/stencila.css
+++ b/director/assets/css/stencila.css
@@ -11714,6 +11714,8 @@ button.dropdown-item {
   border-radius: 4px;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
   font-weight: 600; }
+  .box:not(:last-child) {
+    margin-bottom: 1rem; }
 
 a.box:hover, a.box:focus {
   color: #2568ef;
@@ -11738,6 +11740,9 @@ a.box:active {
   height: auto;
   width: auto;
   max-width: 100%; }
+
+.table a, .addon-notes-container table a {
+  font-weight: normal !important; }
 
 .tabs a {
   text-decoration: none !important; }

--- a/director/assets/css/styles.css
+++ b/director/assets/css/styles.css
@@ -12687,6 +12687,8 @@ button[type="submit"] {
   border-radius: 4px;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
   font-weight: 600; }
+  .box:not(:last-child) {
+    margin-bottom: 1rem; }
 
 a.box:hover, a.box:focus {
   color: #2568ef;
@@ -12711,6 +12713,9 @@ a.box:active {
   height: auto;
   width: auto;
   max-width: 100%; }
+
+.table a, .addon-notes-container table a {
+  font-weight: normal !important; }
 
 .tabs a {
   text-decoration: none !important; }
@@ -12824,10 +12829,6 @@ a.box:active {
   padding: 0 0.5rem;
   min-width: auto; }
 
-.button, input[type="submit"],
-button[type="submit"] {
-  text-decoration: none; }
-
 button.hamburger {
   line-height: 0; }
 
@@ -12889,11 +12890,14 @@ button.hamburger {
       justify-content: flex-end;
       margin-right: 1.25rem !important; } }
 
-.content a {
+.content p a, .section p a {
   font-weight: 700;
   text-decoration: underline; }
-  .content a:hover {
+  .content p a:hover, .section p a:hover {
     text-decoration: none; }
+
+.content a.button, .section a.button {
+  text-decoration: none; }
 
 .form-actions {
   text-align: right; }
@@ -12903,10 +12907,13 @@ button.hamburger {
 
 input[type="submit"],
 button[type="submit"] {
-  line-height: 0 !important; }
+  line-height: 0 !important;
+  padding: 1.125rem 1.375rem;
+  text-transform: uppercase;
+  font-weight: 700; }
   .modal-card-foot input[type="submit"], .modal-card-foot
   button[type="submit"] {
-    border-radius: 2px; }
+    padding: 1.125rem 1.375rem; }
 
 .dropdown {
   display: inline-flex;

--- a/director/assets/js/delete-confirm-modal.js
+++ b/director/assets/js/delete-confirm-modal.js
@@ -10,10 +10,10 @@ Vue.component('delete-confirm-modal', {
         '                <form class="form" method="POST" :action="formAction">\n' +
         '                    <slot name="csrf_token"></slot>\n' +
         '                    <input type="hidden" :name="deleteIdName" value="" v-model="deleteIdValue">\n' +
-        '                    <button class="button is-danger" type="submit" name="action" :value="deleteAction">\n' +
+        '                    <button class="button is-danger is-rounded" type="submit" name="action" :value="deleteAction">\n' +
         '                        [[ deleteButtonLabel ]]\n' +
         '                    </button>\n' +
-        '                    <a class="button" href="#" @click.prevent="hideDeleteModal()">Cancel</a>\n' +
+        '                    <a class="button is-rounded call-to-action" href="#" @click.prevent="hideDeleteModal()">Cancel</a>\n' +
         '                </form>\n' +
         '            </footer>\n' +
         '        </b-modal>',

--- a/director/assets/sass/form/elements/_submit-button.sass
+++ b/director/assets/sass/form/elements/_submit-button.sass
@@ -9,5 +9,10 @@ button[type="submit"]
 
     line-height: 0 !important
 
+    // Align styles with call-to-action
+    padding: $stencila-call-to-action-padding
+    text-transform: uppercase
+    font-weight: $weight-semibold
+
     .modal-card-foot &
-      border-radius: $radius-small
+        padding: $stencila-call-to-action-padding

--- a/director/assets/sass/imports/_overrides.sass
+++ b/director/assets/sass/imports/_overrides.sass
@@ -2,7 +2,6 @@
 /// collection of imports for overrides
 ////
 @import '@stencila/style/sass/imports/_bulma-overrides.sass'
-@import '../overrides/button'
 @import '../overrides/hamburger'
 @import '../overrides/bulma/navbar'
 @import '../overrides/typography'

--- a/director/assets/sass/overrides/_button.sass
+++ b/director/assets/sass/overrides/_button.sass
@@ -1,5 +1,0 @@
-////
-/// Button overrides
-////
-.button
-    text-decoration: none !important

--- a/director/assets/sass/overrides/_button.sass
+++ b/director/assets/sass/overrides/_button.sass
@@ -2,4 +2,4 @@
 /// Button overrides
 ////
 .button
-    text-decoration: none
+    text-decoration: none !important

--- a/director/assets/sass/overrides/_typography.sass
+++ b/director/assets/sass/overrides/_typography.sass
@@ -1,10 +1,10 @@
 ////
 /// Typography overrides.
 ////
-.content
-    a
+.content, .section
+    a:not(.box):not(.call-to-action):not(.dropdown-item)
         font-weight: $weight-bold
         text-decoration: underline
-        
+
         &:hover
             text-decoration: none

--- a/director/assets/sass/overrides/_typography.sass
+++ b/director/assets/sass/overrides/_typography.sass
@@ -2,9 +2,15 @@
 /// Typography overrides.
 ////
 .content, .section
-    a:not(.box):not(.call-to-action):not(.dropdown-item)
+    p
+      a
         font-weight: $weight-bold
         text-decoration: underline
 
         &:hover
+            text-decoration: none
+
+
+    a
+        &.button
             text-decoration: none

--- a/director/assets/sass/styles.sass
+++ b/director/assets/sass/styles.sass
@@ -43,7 +43,7 @@ $stencila-dropdown-font-weight: $weight-light
 $footer-height: 136px
 
 body, html
-  height: 100%
+    height: 100%
 
 #body
     min-height: 100%

--- a/director/package-lock.json
+++ b/director/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
     },
     "@stencila/style": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@stencila/style/-/style-1.1.9.tgz",
-      "integrity": "sha512-Paqs8+s8GAj4LmA2Z76oBGLxFUyijWQTSlv8E+tiW+hTNglarnGd019gEa2z8mVYk6Q6aJIJSKhOUTBi+b+zJA==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@stencila/style/-/style-1.1.10.tgz",
+      "integrity": "sha512-h4EfduX0Zu3qfW/dcKhDyNSym8KXJjAUfoVWcwHJ6DHZRroz4iZYvASzpKofgt1ROLsNb+KVzRMFKFXNGGoCCw==",
       "requires": {
         "gulp-rename": "^1.4.0"
       }

--- a/director/package.json
+++ b/director/package.json
@@ -9,7 +9,7 @@
         "start": "gulp"
     },
     "dependencies": {
-        "@stencila/style": "^1.1.9",
+        "@stencila/style": "^1.1.10",
         "buefy": "^0.7.2",
         "bulma": "^0.7.4",
         "gulp": "^4.0.0",

--- a/director/projects/templates/projects/project_archives.html
+++ b/director/projects/templates/projects/project_archives.html
@@ -54,12 +54,12 @@
             {% endfor %}
             </tbody>
         </table>
-        <div class="container" style="margin-bottom: 15px;">
+        <div class="column is-full" style="margin-bottom: 15px;">
             <h4 class="subtitle is-4">Create Archive</h4>
             <p>Create a zip file of the files in this project. The file name contains the date the archive was
                 created.</p>
         </div>
-        <div class="container">
+        <div class="column is-full">
             {% crispy form %}
         </div>
     </section>

--- a/director/projects/templates/projects/project_files.html
+++ b/director/projects/templates/projects/project_files.html
@@ -152,11 +152,13 @@
                 </td>
                 <td>
                     {% if directory_entry.is_directory %}
-                        <a href="{% source_path project directory_entry %}">
+                      <p>
+                          <a href="{% source_path project directory_entry %}">
                     {% endif %}
                     {{ directory_entry.name }}
                     {% if directory_entry.is_directory %}
-                        </a>
+                          </a>
+                      </p>
                     {% endif %}
                 </td>
 

--- a/director/projects/templates/projects/project_list.html
+++ b/director/projects/templates/projects/project_list.html
@@ -61,7 +61,7 @@
             </a>
         {% empty %}
             <div>
-                It appears that you have no projects. Click the <em>New</em> button above to get started!
+                It appears that you have no projects. Click on <em>New Project</em> to get started!
             </div>
         {% endfor %}
     </div>

--- a/director/projects/templates/projects/project_list.html
+++ b/director/projects/templates/projects/project_list.html
@@ -45,29 +45,23 @@
 
             {% if request.user.is_authenticated %}
                 <p class="level-item">
-                    <a class="button is-success" href="{% url 'project_create' %}">
+                    <a class="button is-primary is-rounded is-outlined call-to-action" href="{% url 'project_create' %}">
                         <span class="icon"><i class="fas fa-plus"></i></span>
-                        <span>New</span>
+                        <span>New Project</span>
                     </a>
                 </p>
             {% endif %}
         </div>
     </nav>
 
-    <div class="section">
+    <div class="section section--inner">
         {% for project in object_list %}
-            <div class="card">
-                <div class="card-content">
-                    <a href="{% url 'project_overview' project.id %}" title="Open">
-                        <span>{{ project.get_name }}</span>
-                    </a>
-                </div>
-            </div>
+            <a class="box" href="{% url 'project_overview' project.id %}" title="Open">
+                <span>{{ project.get_name }}</span>
+            </a>
         {% empty %}
             <div>
-                <div class="card-content">
-                    It appears that you have no projects. Click the <em>New</em> button above to get started!
-                </div>
+                It appears that you have no projects. Click the <em>New</em> button above to get started!
             </div>
         {% endfor %}
     </div>

--- a/director/projects/templates/projects/project_overview.html
+++ b/director/projects/templates/projects/project_overview.html
@@ -4,7 +4,7 @@
 
 {% block content %}
     {% include "projects/_project_header.html" with project=project tab="overview" %}
-    <div class="section">
+    <div class="section section--inner">
         <div class="container">
             <p>This project is connected to the account: <strong> {{ project.account.name }}</strong></p>
             <br/>

--- a/director/templates/_header.html
+++ b/director/templates/_header.html
@@ -15,8 +15,8 @@
                 <div class="navbar-end is-flex align-centre">
                     {% if user.is_anonymous %}
                     <div class="buttons">
-                        <a class="button is-mini is-outlined is-primary is-rounded call-to-action" href="{% url 'user_signin' %}">Sign in</a>
-                        <a class="button is-mini is-outlined is-primary is-rounded call-to-action" href="{% url 'user_signup' %}">Sign up</a>
+                        <a class="button is-outlined is-primary is-rounded call-to-action" href="{% url 'user_signin' %}">Sign in</a>
+                        <a class="button is-outlined is-primary is-rounded call-to-action" href="{% url 'user_signup' %}">Sign up</a>
                     </div>
                     {% else %}
                     <div class="has-dropdown">
@@ -45,7 +45,7 @@
                                         <a class="dropdown-item" href="{% url 'user_settings' %}">Settings</a>
                                         <hr class="dropdown-divider">
                                         <div class="dropdown-item no-hover is-flex">
-                                            <a class="button is-mini is-outlined is-primary is-rounded call-to-action" href="{% url 'user_signout' %}">Sign out</a>
+                                            <a class="button is-outlined is-primary is-rounded call-to-action" href="{% url 'user_signout' %}">Sign out</a>
                                         </div>
 
                                     </div>

--- a/director/templates/base.html
+++ b/director/templates/base.html
@@ -36,8 +36,12 @@
         {% block main %}
         <main id="main_section" class="section">
             <div class="container">
-                {% include "_messages.html" %}
-                {% block content %}{% endblock %}
+                <div class="columns is-centered">
+                    <div class="column is-full">
+                        {% include "_messages.html" %}
+                        {% block content %}{% endblock %}
+                    </div>
+                </div>
             </div>
         </main>
         {% endblock %}

--- a/director/users/templates/beta_token.html
+++ b/director/users/templates/beta_token.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 <div class="columns is-centered">
-    <div class="column is-half">
+    <div class="column is-three-quarters">
         <div class="content">
             <h1 class="title is-3">
                 Beta testing
@@ -27,7 +27,7 @@
 </div>
 
 <div class="columns is-centered">
-    <div class="column is-half">
+    <div class="column is-three-quarters">
         {% crispy form %}
     </div>
 </div>

--- a/director/users/templates/users/signin.html
+++ b/director/users/templates/users/signin.html
@@ -7,7 +7,7 @@
 
 {% block content %}
 <div class="columns is-centered">
-    <div class="column is-half">
+    <div class="column is-three-quarters">
         <h1 class="title">Sign in</h1>
         <form class="form" method="post" action="{% url 'user_signin' %}">
             {% csrf_token %}
@@ -28,28 +28,26 @@
                     </div>
                 </div>
             </div>
-
         </form>
-
     </div>
 </div>
 <div class="columns is-centered">
-    <div class="column is-half">
+    <div class="column is-three-quarters">
         <h3 class="title is-6">Or sign in using one of these services</h3>
-        <div class="buttons is-centered">
-            <a class="button call-to-action is-rounded is-borderless is-mini is-dark" title="Github" href="{% provider_login_url 'github' process='login' %}">
+        <div class="buttons">
+            <a class="button call-to-action is-rounded is-dark" title="Github" href="{% provider_login_url 'github' process='login' %}">
                 <span class="icon"><i class="fab fa-github"></i></span>
                 <span>GitHub</span>
             </a>
-            <a class="button call-to-action is-rounded is-borderless is-mini is-dark" title="Google" href="{% provider_login_url 'google' process='login' %}">
+            <a class="button call-to-action is-rounded is-dark" title="Google" href="{% provider_login_url 'google' process='login' %}">
                 <span class="icon"><i class="fab fa-google"></i></span>
                 <span>Google</span>
             </a>
-            <a class="button call-to-action is-rounded is-borderless is-mini is-dark" title="ORCID" href="{% provider_login_url 'orcid' process='login' %}">
+            <a class="button call-to-action is-rounded is-dark" title="ORCID" href="{% provider_login_url 'orcid' process='login' %}">
                 <span class="icon"><i class="fas fa-user"></i></span>
                 <span>ORCID</span>
             </a>
-            <a class="button call-to-action is-rounded is-borderless is-mini is-dark" title="Twitter" href="{% provider_login_url 'twitter' process='login' %}">
+            <a class="button call-to-action is-rounded is-dark" title="Twitter" href="{% provider_login_url 'twitter' process='login' %}">
                 <span class="icon"><i class="fab fa-twitter"></i></span>
                 <span>Twitter</span>
             </a>

--- a/director/users/templates/users/signout.html
+++ b/director/users/templates/users/signout.html
@@ -30,7 +30,7 @@
                 <button class="button is-primary" type="submit">
                     Yes, just sign me out!
                 </button>
-                <a class="button" href="/">
+                <a class="button is-rounded call-to-action" href="/">
                     No, I'll stick around
                 </a>
             </form>


### PR DESCRIPTION
Related to https://github.com/stencila/style/pull/7.

* **fix(signout, signin, beta_token, header, modal):** aligning button styles with stencila brand guidelines (blue rounded buttons) + using three-quarters-sized columns instead of half-sized columns.
* **fix(account_list, project_list, project_archives, project_overview, base):** using columns in base and project_archives. Using section--inner class for project_overview, project_list, and account_list. Aligning buttons and listed items with branding guidelines in account_list, project_list. Using box instead of card.
* **fix(buttons, anchors):** Aligning hub submit button styles with call-to-action. Removing text decoration from buttons. Making sure anchors are underlined/bolded for appropriate elements (not in box, call-to-action, or dropdown-item).

_Projects List (before, using card):_
<img width="1044" alt="Screenshot 2019-03-16 18 58 12" src="https://user-images.githubusercontent.com/10161095/54575164-414abe80-49b0-11e9-9757-038b2b371b43.png">

_Signin (before, half-sized columns, smaller CTAs, no anchor underlines):_
![Screenshot 2019-03-18 19 08 48](https://user-images.githubusercontent.com/10161095/54575618-fc278c00-49b1-11e9-9a9a-b39a0c481fd3.png)

_Modal (before, submit button style):_
![Screenshot 2019-03-18 19 07 12](https://user-images.githubusercontent.com/10161095/54575622-ffbb1300-49b1-11e9-9f95-3cbbcd11da7e.png)

_Projects List (after, using box, underlined anchors, and updated CTA style):_
![Screenshot 2019-03-18 11 36 59](https://user-images.githubusercontent.com/10161095/54575172-460f7280-49b0-11e9-93c3-1bd8b274be12.png)

_Signin (after, using three-quarters-sized columns, aligned CTA/button styles, underlined anchors)_
![Screenshot 2019-03-18 19 12 39](https://user-images.githubusercontent.com/10161095/54575636-16616a00-49b2-11e9-846d-9e6f8caa4ef1.png)

_Modal (after, updated submit button and anchor styles):_
![Screenshot 2019-03-18 19 12 01](https://user-images.githubusercontent.com/10161095/54575638-16fa0080-49b2-11e9-90a3-0e18557ac8d0.png)