### PR TITLE
fix(Landing Page): Make URL and upload options side-by-side

### DIFF
--- a/director/assets/sass/styles.sass
+++ b/director/assets/sass/styles.sass
@@ -80,6 +80,12 @@ body, html
   .column
     padding-bottom: 0
 
+.open-landing-form
+  .control
+    input,
+    .button
+      height: 2.75rem
+
 .open-footer
   padding-top: 0
   img

--- a/director/stencila_open/templates/open/main.html
+++ b/director/stencila_open/templates/open/main.html
@@ -9,15 +9,19 @@
     <section class="section">
         <div class="columns">
             <div class="column is-8 is-offset-2">
-                <h1 class="title is-size-4-mobile has-text-centered">
+                <h1 class="title is-size-4-mobile is-spaced has-text-centered">
                   Reproducible research collaboration &amp; publication, minus&nbsp;the&nbsp;headaches.
                 </h1>
 
                 <h2 class="subtitle is-5 has-text-centered">
                     Need to share your <span id="informat-example">Jupyter notebook</span> with your supervisor as a Word document for&nbsp;sign&#8209;off?&nbsp;Easy&nbsp;peasy.
                 </h2>
-
-                <form method="post">
+                
+            </div>
+        </div>
+        <div class="columns is-vcentered">
+            <div class="column is-4 is-offset-1">
+                <form method="post" class="open-landing-form">
                     {% csrf_token %}
                     <label for="{{ url_form.url.auto_id }}" class="label">
                         Enter a file URL
@@ -110,14 +114,13 @@
                     {% endif %}
                 </form>
             </div>
-        </div>
-        <div class="columns">
-            <div class="column is-8 is-offset-2">
+            <div class="column is-2">
                 <p class="is-uppercase-heading has-text-centered">&ndash; OR &ndash;</p>
             </div>
-        </div>
-        <div class="columns">
-            <div class="column is-8 is-offset-2">
+            <div class="column is-3">
+                <div class="is-hidden-mobile">
+                    <br/>
+                </div>
                 <form method="post" enctype="multipart/form-data" id="id_file_form">
                     {% csrf_token %}
                     <input type="hidden" name="mode" value="file">


### PR DESCRIPTION
* added space between main heading and tagline
* display URL and upload options side-by-side

Updated desktop landing:
![Screen Shot 2019-10-02 at 10 10 26 AM](https://user-images.githubusercontent.com/10161095/66065751-faac5400-e4fc-11e9-925e-55fefe38b691.png)

---
![Screen Shot 2019-10-02 at 10 12 36 AM](https://user-images.githubusercontent.com/10161095/66065860-2fb8a680-e4fd-11e9-849b-0bd81e274ad2.png)

