### PR TITLE
/Open header refinements

### DIFF
--- a/director/assets/css/styles.css
+++ b/director/assets/css/styles.css
@@ -21435,6 +21435,13 @@ body, html {
   padding-bottom: 0;
 }
 
+.open-landing-form .control input,
+.open-landing-form .control .button,
+.open-landing-form .control input[type="submit"],
+.open-landing-form .control button[type="submit"] {
+  height: 2.75rem;
+}
+
 .open-footer {
   padding-top: 0;
 }
@@ -21614,6 +21621,11 @@ h6.has-top-margin {
   height: 1.5rem;
   margin-bottom: 1rem;
   margin-right: .5rem;
+}
+
+#informat-example {
+  background-color: rgba(102, 255, 102, 0.16);
+  padding: 2px 4px;
 }
 
 .open-feature-list .columns {

--- a/director/assets/css/styles.css
+++ b/director/assets/css/styles.css
@@ -18807,7 +18807,7 @@ a.navbar-item:focus, a.navbar-item:focus-within, a.navbar-item:hover, a.navbar-i
   display: inline-block;
 }
 
-.tooltip-link:hover .tooltip {
+.tooltip-link:hover .tooltip, .tooltip-link:focus .tooltip {
   display: inline-block;
 }
 

--- a/director/assets/sass/atoms/_tooltip.sass
+++ b/director/assets/sass/atoms/_tooltip.sass
@@ -3,7 +3,7 @@
 ////
 .tooltip-link
     display: inline-block
-    &:hover
+    &:hover, &:focus
         .tooltip
             display: inline-block
 

--- a/director/assets/sass/styles.sass
+++ b/director/assets/sass/styles.sass
@@ -80,6 +80,12 @@ body, html
   .column
     padding-bottom: 0
 
+.open-landing-form
+  .control
+    input,
+    .button
+      height: 2.75rem
+
 .open-footer
   padding-top: 0
   img

--- a/director/assets/sass/styles.sass
+++ b/director/assets/sass/styles.sass
@@ -232,6 +232,10 @@ h6.has-top-margin
   margin-bottom: 1rem
   margin-right: .5rem
 
+#informat-example
+    background-color: rgba($success, .16)
+    padding: 2px 4px
+
 .open-feature-list
   .columns
     margin-top: 1.5rem

--- a/director/stencila_open/templates/open/main.html
+++ b/director/stencila_open/templates/open/main.html
@@ -14,7 +14,7 @@
                 </h1>
 
                 <h2 class="subtitle is-5 has-text-centered">
-                    Need to share your <span id="informat-example">Jupyter notebook</span> with your supervisor as a Word document for&nbsp;sign&#8209;off?&nbsp;Easy&nbsp;peasy.
+                  Need to share your <span id="informat-example">Jupyter notebook</span> with your supervisor<br /> as a Word document for&nbsp;sign&#8209;off?&nbsp;Easy&nbsp;peasy.
                 </h2>
                 
             </div>

--- a/director/stencila_open/templates/open/main.html
+++ b/director/stencila_open/templates/open/main.html
@@ -9,15 +9,19 @@
     <section class="section">
         <div class="columns">
             <div class="column is-8 is-offset-2">
-                <h1 class="title is-size-4-mobile has-text-centered">
+                <h1 class="title is-size-4-mobile is-spaced has-text-centered">
                   Reproducible research collaboration &amp; publication, minus&nbsp;the&nbsp;headaches.
                 </h1>
 
                 <h2 class="subtitle is-5 has-text-centered">
                     Need to share your <span id="informat-example">Jupyter notebook</span> with your supervisor as a Word document for&nbsp;sign&#8209;off?&nbsp;Easy&nbsp;peasy.
                 </h2>
-
-                <form method="post">
+                
+            </div>
+        </div>
+        <div class="columns is-vcentered">
+            <div class="column is-4 is-offset-1">
+                <form method="post" class="open-landing-form">
                     {% csrf_token %}
                     <label for="{{ url_form.url.auto_id }}" class="label">
                         Enter a file URL
@@ -110,14 +114,13 @@
                     {% endif %}
                 </form>
             </div>
-        </div>
-        <div class="columns">
-            <div class="column is-8 is-offset-2">
+            <div class="column is-2">
                 <p class="is-uppercase-heading has-text-centered">&ndash; OR &ndash;</p>
             </div>
-        </div>
-        <div class="columns">
-            <div class="column is-8 is-offset-2">
+            <div class="column is-3">
+                <div class="is-hidden-mobile">
+                    <br/>
+                </div>
                 <form method="post" enctype="multipart/form-data" id="id_file_form">
                     {% csrf_token %}
                     <input type="hidden" name="mode" value="file">

--- a/director/stencila_open/templates/open/main.html
+++ b/director/stencila_open/templates/open/main.html
@@ -53,7 +53,7 @@
                             <a href="#">Article 4</a> (.docx)
                         </p>
                     {% endcomment %}
-                    <div><a href="#" class="help tooltip-link">What types of URLs can I enter?
+                    <div><a href="javascript:void(0)" class="help tooltip-link">What types of URLs can I enter?
                         <span class="tooltip-q">?
                             <div class="tooltip is-hidden-mobile">
                                 <p class="is-uppercase-heading has-bottom-margin">Supported sites and formats</p>
@@ -143,7 +143,7 @@
                             </span>
                         </label>
                     </div>
-                    <div class="has-text-centered"><a href="#" class="help tooltip-link">What types of files can I upload?
+                    <div class="has-text-centered"><a href="javascript:void(0)" class="help tooltip-link">What types of files can I upload?
                         <span class="tooltip-q">?
                             <div class="tooltip is-hidden-mobile">
                                 <p class="is-uppercase-heading has-bottom-margin">Supported file formats</p>
@@ -181,7 +181,7 @@
                             </p>
                         </div>
                     {% endif %}
-                    <div class="has-text-centered"><a href="#" class="help tooltip-link">How is my data used?
+                    <div class="has-text-centered"><a href="javascript:void(0)" class="help tooltip-link">How is my data used?
                         <span class="tooltip-q">?
                             <div class="tooltip is-hidden-mobile">
                                 <p class="is-uppercase-heading has-bottom-margin">How is my data used?</p>
@@ -342,7 +342,6 @@
     {% block open_scripts %}
         <script src="https://cdn.jsdelivr.net/npm/typed.js@2.0.11"></script>
         <script>
-
         var typed = new Typed('#informat-example',  {
            strings: ['Jupyter notebook', 'R Markdown file', 'GitHub file', 'R Notebook'],
           startDelay: 3000,
@@ -358,6 +357,8 @@
           fileField.onchange = function () {
             if (fileField.files.length === 1) document.getElementById('id_file_form').submit()
           }
+
+
         </script>
     {% endblock %}
     {% include "open/open_footer.html" %}

--- a/director/stencila_open/templates/open/main.html
+++ b/director/stencila_open/templates/open/main.html
@@ -14,7 +14,7 @@
                 </h1>
 
                 <h2 class="subtitle is-5 has-text-centered">
-                  Need to share your <span id="informat-example">Jupyter notebook</span> with your supervisor<br /> as a Word document for&nbsp;sign&#8209;off?&nbsp;Easy&nbsp;peasy.
+                  Need to share your <span id="informat-example">Jupyter Notebook</span> with your supervisor<br /> as a Word document for&nbsp;sign&#8209;off?&nbsp;Easy&nbsp;peasy.
                 </h2>
                 
             </div>
@@ -345,15 +345,14 @@
     {% block open_scripts %}
         <script src="https://cdn.jsdelivr.net/npm/typed.js@2.0.11"></script>
         <script>
-        var typed = new Typed('#informat-example',  {
-           strings: ['Jupyter notebook', 'R Markdown file', 'GitHub file', 'R Notebook'],
+        var typed = new Typed('#informat-example', {
+          strings: ['R Notebook', 'R Markdown file', 'GitHub file', 'Jupyter Notebook'],
           startDelay: 3000,
           typeSpeed: 50,
           backSpeed: 20,
           loop: true,
           backDelay: 4000,
           showCursor: false
-
         });
 
           let fileField = document.getElementById('{{ file_form.file.auto_id }}')


### PR DESCRIPTION
This branch is based on https://github.com/stencila/hub/pull/259, it builds upon the linked PR by:
-  Preventing content jumping around due to animated header text
- Stylizes the animated text a bit to help distinguish the part that is changing
- Reorder animated strings to promote Jupyter Notebooks. There is still a bit of jank with the looping, can potentially take a look at the library next week if we want.
    - Due to issue with Typed.js library, the first string seems to be skipped
mattboldt/typed.js#392

⚠️  This PR should either be merged into https://github.com/stencila/hub/pull/259, before https://github.com/stencila/hub/pull/259 gets merged into master. Or the target branch of this PR should be changed to point to `master`.

---

## Before

![Kapture 2019-10-04 at 17 21 36](https://user-images.githubusercontent.com/1646307/66242249-372fa980-e6cf-11e9-8f0c-385e58089eb7.gif)

## After

![Kapture 2019-10-04 at 17 19 43](https://user-images.githubusercontent.com/1646307/66242256-3c8cf400-e6cf-11e9-99c8-d5cfda016078.gif)
