### PR TITLE
chore: Refactor mobile /open menus

### DIFF
--- a/director/assets/css/styles.css
+++ b/director/assets/css/styles.css
@@ -19569,6 +19569,7 @@ button:hover:not(.btn-primary[disabled])[type="submit"] {
 
 .main-navbar {
   border-top: 4px solid #2568ef;
+  z-index: 1;
 }
 
 @media screen and (max-width: 1023px) {
@@ -21728,4 +21729,13 @@ h6.has-top-margin {
 #loading-mask div {
   width: 50%;
   text-align: center;
+}
+
+#open-navbar {
+  z-index: 0;
+  height: 0;
+}
+
+#open-navbar.is-active {
+  height: auto;
 }

--- a/director/assets/sass/overrides/bulma/_navbar.sass
+++ b/director/assets/sass/overrides/bulma/_navbar.sass
@@ -3,7 +3,8 @@
 ////
 .main-navbar
     border-top: 4px solid $primary
-    
+    z-index: 1
+
     .container
         @include until($desktop)
             flex-direction: row

--- a/director/assets/sass/styles.sass
+++ b/director/assets/sass/styles.sass
@@ -47,9 +47,11 @@ $stencila-dropdown-font-weight: $weight-light
   width: 150px
 
 .has-text-warning
-  color: #FFA800 !important  // Bulma defines this with !important so we must do that too
+  color: #FFA800 !important
+// Bulma defines this with !important so we must do that too
 
-$header-height: 78px  // This is only currently used in iframe size calc, this size might be implicit
+$header-height: 78px
+// This is only currently used in iframe size calc, this size might be implicit
 $footer-height: 136px
 
 body, html
@@ -76,7 +78,7 @@ body, html
 
   .container
     height: 100%
-  
+
   .column
     padding-bottom: 0
 
@@ -88,11 +90,12 @@ body, html
 
 .open-footer
   padding-top: 0
+
   img
     width: 1rem
     vertical-align: text-bottom
     margin-right: 4px
-  
+
   a
     font-size: 1rem
     color: rgba(0, 0, 0, 0.5)
@@ -190,6 +193,7 @@ a.box:hover .title
 .switch[type=checkbox]
   & + label
     font-size: 14px
+
   &:checked + label::before
     background-color: $primary
 
@@ -219,7 +223,7 @@ h6.has-top-margin
   opacity: 0
 
 .is-uppercase-heading
-    +uppercase-heading
+  +uppercase-heading
 
 .heading-circle
   background-color: rgba(0, 0, 0, 0.1)
@@ -233,14 +237,14 @@ h6.has-top-margin
   margin-right: .5rem
 
 #informat-example
-    background-color: rgba($success, .16)
-    padding: 2px 4px
+  background-color: rgba($success, .16)
+  padding: 2px 4px
 
 .open-feature-list
   .columns
     margin-top: 1.5rem
-    padding-top: 1.5rem    
-  
+    padding-top: 1.5rem
+
 .open-embed
   width: 100%
   height: calc(100vh - #{$footer-height + $header-height})
@@ -272,6 +276,7 @@ h6.has-top-margin
 
   .button.is-borderless
     background-color: transparent
+
     .is-borderless-text
       text-decoration: underline
 
@@ -287,6 +292,7 @@ $share-width: 450px
     width: $share-width
     padding: 20px
     left: -$share-offset
+
     &:before
       left: ($share-width / 2) + $share-offset
 
@@ -294,8 +300,10 @@ $share-width: 450px
 .feedback-rating
   .column
     cursor: pointer
+
     h6
       padding-top: 10px
+
     p
       font-style: italic
       font-size: 80%
@@ -323,3 +331,10 @@ $share-width: 450px
   div
     width: 50%
     text-align: center
+
+#open-navbar
+  z-index: 0
+  height: 0
+
+  &.is-active
+    height: auto

--- a/director/stencila_open/templates/open/_more_dropdown.html
+++ b/director/stencila_open/templates/open/_more_dropdown.html
@@ -16,7 +16,7 @@
                 </span>
                 <span>Open in Google Structured Data Testing Tool</span>
             </a>
-            {%  if log_messages %}
+            {% if log_messages %}
             <a class="dropdown-item" href="#" @click.prevent="showWarningsModal()">
                 <span class="icon">
                     <i class="fas fa-exclamation-triangle"></i>

--- a/director/stencila_open/templates/open/_open_mobile_modals.html
+++ b/director/stencila_open/templates/open/_open_mobile_modals.html
@@ -1,0 +1,127 @@
+<div id="open-modals">
+    <div class="modal" :class="{'is-active': downloadModalVisible}">
+        <div class="modal-background"></div>
+        <div class="modal-card">
+            <header class="modal-card-head">
+                <p class="modal-card-title">Download</p>
+                <button class="delete" aria-label="close" @click="toggleDownloadModal()"></button>
+            </header>
+            <section class="modal-card-body">
+                <nav class="panel">
+                    {% for download_option in download_options %}
+                        {% if download_option is None %}
+                            <!--hr class="dropdown-divider"-->
+                        {% else %}
+                            <a class="panel-block" href="{{ raw_source }}?download={{ download_option.format_id }}"
+                               @click="toggleDownloadModal()">
+                                <span class="panel-icon">
+                                    <i class="{{ download_option.icon_class }}" aria-hidden="true"></i>
+                                </span>
+                                {{ download_option.name }}
+                            </a>
+                        {% endif %}
+                    {% endfor %}
+                </nav>
+            </section>
+            <footer class="modal-card-foot">
+                <button class="button is-primary is-fullwidth" @click="toggleDownloadModal()">Close</button>
+            </footer>
+        </div>
+    </div>
+    <div class="modal" :class="{'is-active': themeModalVisible}">
+        <div class="modal-background"></div>
+        <div class="modal-card">
+            <header class="modal-card-head">
+                <p class="modal-card-title">Theme</p>
+                <button class="delete" aria-label="close" @click="toggleThemeModal()"></button>
+            </header>
+            <section class="modal-card-body">
+                <nav class="panel">
+                    {% for theme in themes %}
+                        <a class="panel-block" @click.prevent="setTheme('{{ theme.theme_id }}')">
+                            <span class="panel-icon">
+                                <i class="fas"
+                                   :class="{'fa-fw': currentTheme !== '{{ theme.theme_id }}', 'fa-check': currentTheme === '{{ theme.theme_id }}' }"
+                                   aria-hidden="true"></i>
+                            </span>
+                            {{ theme.name }}
+                        </a>
+                    {% endfor %}
+                </nav>
+            </section>
+            <footer class="modal-card-foot">
+                <button class="button is-primary is-fullwidth" @click="toggleThemeModal()">Close</button>
+            </footer>
+        </div>
+    </div>
+    <div class="modal" :class="{'is-active': shareModalVisible}">
+        <div class="modal-background"></div>
+        <div class="modal-card">
+            <header class="modal-card-head">
+                <p class="modal-card-title">Public Share Link</p>
+                <button class="delete" aria-label="close" @click="toggleShareModal()"></button>
+            </header>
+            <section class="modal-card-body">
+                <div class="field is-grouped">
+                    <p class="control is-expanded">
+                        <input class="input" type="text" placeholder="Share URL" readonly="readonly"
+                               value="{{ share_url }}" ref="share-url">
+                    </p>
+                    <p class="control">
+                        <a class="button is-info" href="#" @click="copy()">
+                            <span class="icon is-small">
+                                <i v-if="!postCopy" class="fas fa-copy" aria-hidden="true"></i>
+                                <i v-if="postCopy" class="fas fa-check" aria-hidden="true"></i>
+                            </span>
+                            <span v-if="!postCopy">Copy</span>
+                            <span v-if="postCopy">Copied!</span>
+                        </a>
+                    </p>
+                </div>
+                <p>This link will expire 24 hours after conversion.</p>
+            </section>
+            <footer class="modal-card-foot">
+                <button class="button is-primary is-fullwidth" @click="toggleShareModal()">Close</button>
+            </footer>
+        </div>
+    </div>
+    <div class="modal" :class="{'is-active': moreModalVisible}">
+        <div class="modal-background"></div>
+        <div class="modal-card">
+            <header class="modal-card-head">
+                <p class="modal-card-title">More</p>
+                <button class="delete" aria-label="close" @click="toggleMoreModal()"></button>
+            </header>
+            <section class="modal-card-body">
+                <nav class="panel">
+                    <a href="https://search.google.com/structured-data/testing-tool/u/0/#url={{ absolute_raw_url }}"
+                       target="_blank" rel="noopener" class="panel-block">
+                        <span class="panel-icon">
+                                <i class="fas fa-external-link-alt"></i>
+                        </span>
+                        Open in Google Structured Data Testing Tool
+                    </a>
+
+                    {% if log_messages %}
+                        <a class="panel-block" href="#" @click.prevent="showWarningsModal()">
+                            <span class="panel-icon">
+                                <i class="fas fa-exclamation-triangle"></i>
+                            </span>
+                            View conversion warnings
+                        </a>
+                    {% endif %}
+
+                    <a class="panel-block" href="{% url 'open_main' %}">
+                        <span class="icon">
+                            <i class="fas fa-arrow-left"></i>
+                        </span>
+                        Back to Stencila Open
+                    </a>
+                </nav>
+            </section>
+            <footer class="modal-card-foot">
+                <button class="button is-primary is-fullwidth" @click="toggleMoreModal()">Close</button>
+            </footer>
+        </div>
+    </div>
+</div>

--- a/director/stencila_open/templates/open/_theme_dropdown.html
+++ b/director/stencila_open/templates/open/_theme_dropdown.html
@@ -14,38 +14,14 @@
     </div>
     <div class="dropdown-menu" role="menu">
         <div class="dropdown-content">
-            <a href="#" class="dropdown-item" @click="setTheme('stencila')">
-                        <span class="icon is-small">
-                            <i class="fas"
-                               :class="{'fa-fw': currentTheme !== 'stencila', 'fa-check': currentTheme === 'stencila' }"
-                               aria-hidden="true"></i>
-                        </span>
-                <span>Stencila</span>
-            </a>
-            <a href="#" class="dropdown-item" @click="setTheme('eLife')">
-                        <span class="icon is-small">
-                            <i class="fas"
-                               :class="{'fa-fw': currentTheme !== 'eLife', 'fa-check': currentTheme === 'eLife' }"
-                               aria-hidden="true"></i>
-                        </span>
-                <span>eLife</span>
-            </a>
-            <a href="#" class="dropdown-item" @click="setTheme('nature')">
-                        <span class="icon is-small">
-                            <i class="fas"
-                               :class="{'fa-fw': currentTheme !== 'nature', 'fa-check': currentTheme === 'nature' }"
-                               aria-hidden="true"></i>
-                        </span>
-                <span>Nature</span>
-            </a>
-            <a href="#" class="dropdown-item" @click="setTheme('plos')">
-                        <span class="icon is-small">
-                            <i class="fas"
-                               :class="{'fa-fw': currentTheme !== 'plos', 'fa-check': currentTheme === 'plos' }"
-                               aria-hidden="true"></i>
-                        </span>
-                <span>PLOS</span>
-            </a>
+            {% for theme in themes %}
+                <a class="dropdown-item" @click.prevent="setTheme('{{ theme.theme_id }}')">
+                    <span class="icon is-small">
+                       <i class="fas" :class="{'fa-fw': currentTheme !== '{{ theme.theme_id }}', 'fa-check': currentTheme === '{{ theme.theme_id }}' }" aria-hidden="true"></i>
+                    </span>
+                    <span>{{ theme.name }}</span>
+                </a>
+            {% endfor %}
         </div>
     </div>
 </div>

--- a/director/stencila_open/templates/open/open_header.html
+++ b/director/stencila_open/templates/open/open_header.html
@@ -4,18 +4,81 @@
 {% endblock %}
 {% block navbar_end %}
     {% if conversion_success and not hide_action_buttons %}
-        {% include 'open/_download_dropdown.html' %}
-        {% include 'open/_theme_dropdown.html' %}
-        {% if display_share %}
-            {% include 'open/_share_dropdown.html' %}
-        {% endif %}
-        {% include 'open/_more_dropdown.html' %}
+        <div class="is-hidden-mobile">
+            {% include 'open/_download_dropdown.html' %}
+            {% include 'open/_theme_dropdown.html' %}
+            {% if display_share %}
+                {% include 'open/_share_dropdown.html' %}
+            {% endif %}
+            {% include 'open/_more_dropdown.html' %}
+        </div>
+        <a role="button" class="navbar-burger burger is-hidden-desktop is-hidden-tablet" aria-label="menu"
+           aria-expanded="false" id="open-navbar-burger">
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+        </a>
     {% endif %}
     {% if user.is_anonymous %}
-        <div class="buttons">
+        <div class="buttons is-hidden-mobile">
             <a class="button is-outlined is-primary call-to-action" href="https://stenci.la/#beta-signup">
                 Sign up
             </a>
         </div>
+    {% endif %}
+{% endblock %}
+{% block after_main_nav %}
+    {% if conversion_success and not hide_action_buttons %}
+        <nav class="navbar is-shadowless is-hidden-desktop is-hidden-tablet" id="open-navbar"
+             :class="{ 'is-active': isActive }">
+            <div class="container">
+                <div id="open-navbar-actions" class="navbar-menu" :class="{ 'is-active': isActive }">
+                    <div class="navbar-start">
+                        <div class="navbar-item">
+                            <a class="button is-fullwidth" @click="toggleDownloadModal()">
+                                <span class="icon is-small">
+                                    <i class="fas fa-download" aria-hidden="true"></i>
+                                </span>
+                                <span>Download</span>
+                            </a>
+                        </div>
+                        <div class="navbar-item">
+                            <button class="button is-fullwidth" @click="toggleThemeModal()">
+                                <span class="icon is-small">
+                                    <i class="fas fa-paint-roller" aria-hidden="true"></i>
+                                </span>
+                                <span>Theme</span>
+                            </button>
+                        </div>
+                        {% if display_share %}
+                            <div class="navbar-item">
+                                <button class="button is-fullwidth" @click="toggleShareModal()">
+                                    <span class="icon is-small">
+                                        <i class="fas fa-share" aria-hidden="true"></i>
+                                    </span>
+                                    <span>Share</span>
+                                </button>
+                            </div>
+                        {% endif %}
+                        <div class="navbar-item">
+                            <button class="button is-fullwidth" @click="toggleMoreModal()">
+                                    <span class="icon is-small">
+                                        <i class="fas fa-ellipsis-h" aria-hidden="true"></i>
+                                    </span>
+                                <span>More</span>
+                            </button>
+                        </div>
+                        {% if user.is_anonymous %}
+                            <div class="navbar-item">
+                                <a class="button is-outlined is-primary call-to-action is-fullwidth"
+                                   href="https://stenci.la/#beta-signup">
+                                    Sign up
+                                </a>
+                            </div>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        </nav>
     {% endif %}
 {% endblock %}

--- a/director/stencila_open/templates/open/output.html
+++ b/director/stencila_open/templates/open/output.html
@@ -1,5 +1,6 @@
 {% extends 'open/main.html' %}
 {% block main %}
+    {% include "open/_open_mobile_modals.html" %}
     <div id="loading-mask" class="is-hidden">
         <div>
             <i class="fas fa-5x fa-spinner fa-spin"></i>
@@ -10,6 +11,85 @@
 {% endblock %}
 {% block open_scripts %}
     <script>
+      var CURRENT_THEME = 'stencila'
+
+      if (document.getElementById('open-navbar')) {
+        let openModals = new Vue({
+          el: '#open-modals',
+          data: {
+            downloadModalVisible: false,
+            themeModalVisible: false,
+            shareModalVisible: false,
+            moreModalVisible: false,
+            currentTheme: CURRENT_THEME,
+            postCopy: false
+          },
+          methods: {
+            toggleDownloadModal () {
+              this.downloadModalVisible = !this.downloadModalVisible
+            },
+            toggleThemeModal () {
+              this.currentTheme = CURRENT_THEME
+              this.themeModalVisible = !this.themeModalVisible
+            },
+            toggleShareModal () {
+              this.postCopy = false
+              this.shareModalVisible = !this.shareModalVisible
+            },
+            toggleMoreModal () {
+              this.moreModalVisible = !this.moreModalVisible
+            },
+            setTheme (themeName) {
+              this.currentTheme = themeName
+              CURRENT_THEME = themeName
+              setTheme(themeName, () => {
+                this.toggleThemeModal()
+              })
+            },
+            copy () {
+              const shareUrlInput = this.$refs['share-url']
+              shareUrlInput.focus()
+              shareUrlInput.select()
+              document.execCommand('copy')
+              this.postCopy = true
+            },
+            showWarningsModal () {
+              this.toggleMoreModal()
+              document.getElementById('warnings_modal').classList.add('is-active')
+            }
+          }
+        })
+        let openNavbar = new Vue({
+          el: '#open-navbar',
+          data: {
+            isActive: false
+          },
+          methods: {
+            toggleDownloadModal () {
+              openModals.toggleDownloadModal()
+            },
+            toggleThemeModal () {
+              openModals.toggleThemeModal()
+            },
+            toggleShareModal () {
+              openModals.toggleShareModal()
+            },
+            toggleMoreModal () {
+              openModals.toggleMoreModal()
+            },
+            toggle() {
+              this.isActive = !this.isActive
+            }
+          }
+        })
+
+        if (document.getElementById('open-navbar-burger')) {
+            document.getElementById('open-navbar-burger') .addEventListener('click', function () {
+              this.classList.toggle('is-active')
+              openNavbar.toggle()
+            })
+        }
+      }
       {% if user_owns_conversion %}
         let themeDropdown = null
 
@@ -190,18 +270,36 @@
         })
       }
 
+      function setTheme (themeName, cb) {
+        const themeUrl = `https://unpkg.com/@stencila/thema@<=1/dist/themes/${themeName}/styles.css`
+
+        const loadingMask = document.getElementById('loading-mask')
+
+        const loadingMaskShowTimeout = setTimeout(() => {
+          loadingMask.classList.remove('is-hidden')
+        }, 200)
+
+        fetch(themeUrl).then(() => {
+          articleDisplay.contentDocument.getElementsByTagName('link')[0].setAttribute('href', themeUrl)
+          clearTimeout(loadingMaskShowTimeout)
+          loadingMask.classList.add('is-hidden')
+        })
+        cb()
+      }
+
       if (document.getElementById('theme_dropdown')) {
         themeDropdown = new Vue({
           el: '#theme_dropdown',
           data: {
             active: false,
-            currentTheme: 'stencila'
+            currentTheme: CURRENT_THEME
           },
           methods: {
             toggle () {
               this.active ? this.hide() : this.show()
             },
             show () {
+              this.currentTheme = CURRENT_THEME
               this.active = true
             },
             hide () {
@@ -209,20 +307,10 @@
             },
             setTheme (themeName) {
               this.currentTheme = themeName
-              const themeUrl = `https://unpkg.com/@stencila/thema@<=1/dist/themes/${themeName}/styles.css`
-
-              const loadingMask = document.getElementById('loading-mask')
-
-              const loadingMaskShowTimeout = setTimeout(() => {
-                loadingMask.classList.remove('is-hidden')
-              }, 200)
-
-              fetch(themeUrl).then(() => {
-                articleDisplay.contentDocument.getElementsByTagName('link')[0].setAttribute('href', themeUrl)
-                clearTimeout(loadingMaskShowTimeout)
-                loadingMask.classList.add('is-hidden')
+              CURRENT_THEME = themeName
+              setTheme(themeName, () => {
+                this.hide()
               })
-              this.hide()
             }
           }
         })

--- a/director/stencila_open/views.py
+++ b/director/stencila_open/views.py
@@ -317,6 +317,19 @@ CONVERSION_DOWNLOAD_OPTIONS = [
 ]
 
 
+class ConversionTheme(typing.NamedTuple):
+    theme_id: str
+    name: str
+
+
+THEMES = [
+    ConversionTheme('stencila', 'Stencila'),
+    ConversionTheme('eLife', 'eLife'),
+    ConversionTheme('nature', 'Nature'),
+    ConversionTheme('plos', 'PLOS')
+]
+
+
 class FileDownloadCleanup:
     path: str
 
@@ -391,6 +404,7 @@ class OpenDisplayView(OpenConversionView):
         context['share_url'] = request.build_absolute_uri()
         context['raw_source'] = reverse('open_result_raw', args=(conversion.public_id,))
         context['absolute_raw_url'] = request.build_absolute_uri(context['raw_source'])
+        context['themes'] = THEMES
         context['current_theme'] = request.GET.get('theme')
 
         return render(request, 'open/output.html', context)

--- a/director/templates/_header.html
+++ b/director/templates/_header.html
@@ -9,7 +9,11 @@
                 <a class="navbar-item navbar-logo" href="{% url 'home' %}">
                     <img src="{% static 'img/logo-name.svg' %}" alt="Stencila" width="112px" height="28px">
                 </a>
-                <span class="navbar-item is-brand-tagline is-uppercase-heading" style="margin: 0 0.5em 0 0; padding-left: 0.5em">{% block brand_tagline %}Beta{% endblock %}</span>
+                <span class="navbar-item is-brand-tagline is-uppercase-heading"
+                      style="margin: 0 0.5em 0 0; padding-left: 0.5em">{% block brand_tagline %}
+                    Beta{% endblock %}</span>
+
+
             </div>
             <div class="navbar-menu" :class="{ 'is-active':active }">
                 <div class="navbar-start is-hidden-mobile">
@@ -63,7 +67,9 @@
             </div>
         </div>
     </nav>
+    {% block after_main_nav %}{% endblock %}
 </header>
+
 <script type="text/javascript">
   if (document.getElementById('navbar')) {
     new Vue({
@@ -73,4 +79,6 @@
       }
     })
   }
+
+
 </script>


### PR DESCRIPTION
Made the /open navbar for mobiles into its own navbar, made a burger on the existing one, and the actions are all in modals now.

![image](https://user-images.githubusercontent.com/292725/66274151-125a5280-e8d8-11e9-93dd-fa6258658a4b.png)

![image](https://user-images.githubusercontent.com/292725/66274152-171f0680-e8d8-11e9-96ac-3628172063c0.png)
