### PR TITLE
fix(ConverterMixin): Check for file before removing

### DIFF
--- a/director/projects/source_views.py
+++ b/director/projects/source_views.py
@@ -426,10 +426,10 @@ class ConverterMixin:
             with open(temp_output_path, 'r+b') as temp_output:  # reopen after data has been written
                 output_content = temp_output.read()  # this is in DOCX after conversion
         finally:
-            if use_temp_input_path and os.path.exists(input_path):
+            if use_temp_input_path and input_path and os.path.exists(input_path):
                 unlink(input_path)
 
-            if os.path.exists(temp_output_path):
+            if temp_output_path and os.path.exists(temp_output_path):
                 unlink(temp_output_path)
         return output_content, DOCX_MIMETYPES[0]
 

--- a/director/projects/source_views.py
+++ b/director/projects/source_views.py
@@ -426,10 +426,10 @@ class ConverterMixin:
             with open(temp_output_path, 'r+b') as temp_output:  # reopen after data has been written
                 output_content = temp_output.read()  # this is in DOCX after conversion
         finally:
-            if use_temp_input_path and input_path:
+            if use_temp_input_path and os.path.exists(input_path):
                 unlink(input_path)
 
-            if temp_output_path:
+            if os.path.exists(temp_output_path):
                 unlink(temp_output_path)
         return output_content, DOCX_MIMETYPES[0]
 


### PR DESCRIPTION
This avoid the following error when converting from a linked URL source to a Google Doc:

```bash
ERROR 2020-01-14 01:28:02,102 log 25198 Internal Server Error: /projects/4/files/convert/
Traceback (most recent call last):
  File "/home/nokome/stencila/source/hub/venv/lib/python3.6/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/home/nokome/stencila/source/hub/venv/lib/python3.6/site-packages/django/core/handlers/base.py", line 115, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/home/nokome/stencila/source/hub/venv/lib/python3.6/site-packages/django/core/handlers/base.py", line 113, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/home/nokome/stencila/source/hub/venv/lib/python3.6/site-packages/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/home/nokome/stencila/source/hub/venv/lib/python3.6/site-packages/django/contrib/auth/mixins.py", line 52, in dispatch
    return super().dispatch(request, *args, **kwargs)
  File "/home/nokome/stencila/source/hub/venv/lib/python3.6/site-packages/django/views/generic/base.py", line 97, in dispatch
    return handler(request, *args, **kwargs)
  File "/home/nokome/stencila/source/hub/director/projects/source_views.py", line 469, in post
    self.source_convert(request, project, scf, target_path, target_name, target_type)
  File "/home/nokome/stencila/source/hub/director/projects/source_views.py", line 439, in source_convert
    self.convert_to_google_docs(request, project, scf, target_name, target_path)
  File "/home/nokome/stencila/source/hub/director/projects/source_views.py", line 395, in convert_to_google_docs
    output_content, output_mime_type = self.convert_source_for_google_docs(scf)
  File "/home/nokome/stencila/source/hub/director/projects/source_views.py", line 430, in convert_source_for_google_docs
    unlink(input_path)
FileNotFoundError: [Errno 2] No such file or directory: 'https://elifesciences.org/articles/30274'
```
