### PR TITLE
chore: Fix names for model instances in development db

### DIFF
--- a/director/scripts/create_dev_accounts.py
+++ b/director/scripts/create_dev_accounts.py
@@ -12,9 +12,9 @@ def run(*args):
     assert settings.DEBUG
 
     for account in [
-        'Hapuku University',
-        'Craigiburn College',
-        'Acme Ltd'
+        'hapuku-university',
+        'craigiburn-college',
+        'acme-ltd'
     ]:
         Account.objects.create(
             name=account,

--- a/director/scripts/create_dev_projects.py
+++ b/director/scripts/create_dev_projects.py
@@ -23,7 +23,7 @@ def run(*args):
         account=accounts[0],
         creator=random_account_member(accounts[0]),
         public=True,
-        name='The project name',
+        name='first-project',
         description='''
 The project description. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut la
 bore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex eacom
@@ -33,12 +33,14 @@ xcepteur sint occaecat cupidatat non roident, sunt in culpa qui officia deserunt
     )
 
     Project.objects.create(
+        name='second-project',
         account=accounts[1],
         creator=random_account_member(accounts[1]),
         public=True
     )
 
     Project.objects.create(
+        name='third-project',
         account=accounts[2],
         creator=random_account_member(accounts[2]),
         public=False


### PR DESCRIPTION
Names for `Account` and `Project` now need to be slugs.