### PR TITLE
fix: Move help text into a tool tip to make page less busy

### DIFF
--- a/director/accounts/templates/accounts/account_access.html
+++ b/director/accounts/templates/accounts/account_access.html
@@ -44,6 +44,18 @@
                                 </select>
                             </div>
                         </div>
+                        <a href="javascript:void(0)" class="help tooltip-link">
+                            How do account roles differ?
+                            <span class="tooltip-q">?
+                                <div class="tooltip" style="z-index: 100">
+                                    <p class="is-uppercase-heading has-bottom-margin">Account roles</p>
+                                    <p>
+                                        Account <strong>members</strong> can add projects to the account; <strong>admins</strong> can also make
+                                        other users members of an account, add teams to the account, and change account settings.
+                                    </p>
+                                </div>
+                            </span>
+                        </a>
                     </div>
                 </div>
                 <div class="column">
@@ -53,17 +65,6 @@
                 </div>
             </div>
         </form>
-        <div class="container">
-            <p class="has-top-margin"> You can add users to {{ account.name }} and assign two different roles to them:
-                <em>Admin</em> or <em>Member</em>.</p>
-            <br/>
-            <p><strong>Account admin</strong> can: delete {{ account.name }}; update the billing details; give other
-                users access
-                to the account (including giving them administrative permission); create and add teams to the account.
-            </p>
-            <p><strong>Account member</strong> can only add projects to {{ account.name }}.</p>
-            <br/>
-        </div>
         <table class="table is-fullwidth">
             <thead>
             <tr>


### PR DESCRIPTION
This uses the `.tooltip` classes as on the `/open` page. I struggled to get it to look OK on mobile. Maybe worth putting effort into the tooltip CSS / markup convention to make it usable in various contexts or see if there is a Bulma / Buefy extension for that.

### Before

![image](https://user-images.githubusercontent.com/1152336/72951089-1ca24d00-3df2-11ea-82bf-e546fe7c4df9.png)

### After

![image](https://user-images.githubusercontent.com/1152336/72951048-01cfd880-3df2-11ea-99b2-8a8a96816bb6.png)
