### PR TITLE
Restrict staff capabilities on admin site

### DIFF
--- a/director/projects/project_admin.py
+++ b/director/projects/project_admin.py
@@ -8,19 +8,11 @@ from .models import Project, ProjectPermission, ProjectRole, ProjectAgentRole
 @admin.register(Project)
 class ProjectAdmin(admin.ModelAdmin):
     list_display = [
-        '__str__', 'public', 'archive'
+        'id', 'account', 'name', 'public'
     ]
     list_filter = [
         'public'
     ]
-
-    def archive(self, project):
-        """Link to an archive of the project."""
-        url = reverse('project_archive', args=[project.id])
-        return format_html('<a href="{}">Archive</a>'.format(url))
-
-    archive.short_description = 'Archive'  # type: ignore
-
 
 @admin.register(ProjectPermission)
 class ProjectPermissionAdmin(admin.ModelAdmin):

--- a/director/scripts/create_dev_users.py
+++ b/director/scripts/create_dev_users.py
@@ -12,7 +12,7 @@ def run(*args):
     admin = User.objects.create_user(
         username='admin',
         first_name='Admin',
-        email='admin',
+        email='admin@example.com',
         password='admin'
     )
     admin.is_staff = True
@@ -23,7 +23,7 @@ def run(*args):
     staff = User.objects.create_user(
         username='staff',
         first_name='Staff',
-        email='staff',
+        email='staff@example.com',
         password='staff'
     )
     staff.is_staff = True

--- a/director/scripts/create_dev_users.py
+++ b/director/scripts/create_dev_users.py
@@ -1,6 +1,4 @@
-"""
-Create users for the development database
-"""
+"""Create users for the development database."""
 
 from django.contrib.auth.models import User
 from django.conf import settings
@@ -10,8 +8,10 @@ def run(*args):
     # Ensure that this is only used in development
     assert settings.DEBUG
 
+    # Admin (super user)
     admin = User.objects.create_user(
         username='admin',
+        first_name='Admin',
         email='admin',
         password='admin'
     )
@@ -19,6 +19,17 @@ def run(*args):
     admin.is_superuser = True
     admin.save()
 
+    # Staff member (not super user)
+    staff = User.objects.create_user(
+        username='staff',
+        first_name='Staff',
+        email='staff',
+        password='staff'
+    )
+    staff.is_staff = True
+    staff.save()
+
+    # Normal users
     for user in [
         ('joe', 'Joe', 'Blogs'),
         ('jane', 'Jane', 'Doe'),

--- a/director/settings.py
+++ b/director/settings.py
@@ -70,11 +70,12 @@ class Common(Configuration):
         'djstripe',
 
         # Our apps
-
-        'users',
-        'accounts',
-        'projects',
-        'stencila_open'
+        # Uses dotted paths to AppConfig subclasses as 
+        # recommended in https://docs.djangoproject.com/en/2.2/ref/applications/#configuring-applications
+        'users.apps.UsersConfig',
+        'accounts.apps.AccountsConfig',
+        'projects.apps.ProjectsConfig',
+        'stencila_open.apps.StencilaOpenConfig'
     ]
 
     MIDDLEWARE = [

--- a/director/settings.py
+++ b/director/settings.py
@@ -70,7 +70,7 @@ class Common(Configuration):
         'djstripe',
 
         # Our apps
-        # Uses dotted paths to AppConfig subclasses as 
+        # Uses dotted paths to AppConfig subclasses as
         # recommended in https://docs.djangoproject.com/en/2.2/ref/applications/#configuring-applications
         'users.apps.UsersConfig',
         'accounts.apps.AccountsConfig',

--- a/director/templates/500.html
+++ b/director/templates/500.html
@@ -11,8 +11,16 @@
                 <img class="error-image" src="{% static 'img/dead-document.svg' %}" alt="Oh no!" width="112px"
                      height="28px">
                 <h1 class="title has-margin-top">Oops!</h1>
-                <p>Sorry, it looks like we are having issues. 
-                   Our team has been notified and rectify it as soon as possible!</p>
+                <p>
+                  Sorry, it seems that there is a problem with this page. 
+                  Our team has been notified and will rectify it as soon as possible!
+                </p>
+                <p>
+                  Stencila is an open source product. You can help make it better
+                  (and reduce these problems :) by <a href="https://github.com/stencila/hub#readme">
+                  contributing</a> code, documentation, 
+                  ideas, bug reports etc. 💖.
+                </p>
                 {% if sentry_event_id %}
                   <script>
                     Sentry.showReportDialog({

--- a/director/users/admin.py
+++ b/director/users/admin.py
@@ -25,7 +25,7 @@ class CustomUserAdmin(UserAdmin):
         """
         form = super().get_form(request, obj, **kwargs)
         is_superuser = request.user.is_superuser
-        disabled_fields = set()  # type: Set[str]
+        disabled_fields: Set[str] = set()
 
         if not is_superuser:
             disabled_fields |= {

--- a/director/users/admin.py
+++ b/director/users/admin.py
@@ -1,11 +1,12 @@
 from typing import Set
 
 from django.contrib import admin
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User, Group
 from django.contrib.auth.admin import UserAdmin
 
 # Unregister the default user model admin
 admin.site.unregister(User)
+
 
 @admin.register(User)
 class CustomUserAdmin(UserAdmin):
@@ -30,11 +31,11 @@ class CustomUserAdmin(UserAdmin):
             disabled_fields |= {
                 # Prevent non-superusers from changing usernames
                 'username',
-                # Prevent non-superusers from making a user staff or 
+                # Prevent non-superusers from making a user staff or
                 # a superuser
                 'is_staff',
                 'is_superuser',
-                # Prevent non-superusers from granting permissions to 
+                # Prevent non-superusers from granting permissions to
                 # specific users or groups
                 'user_permissions',
                 'groups'

--- a/director/users/admin.py
+++ b/director/users/admin.py
@@ -1,0 +1,62 @@
+from typing import Set
+
+from django.contrib import admin
+from django.contrib.auth.models import User
+from django.contrib.auth.admin import UserAdmin
+
+# Unregister the default user model admin
+admin.site.unregister(User)
+
+@admin.register(User)
+class CustomUserAdmin(UserAdmin):
+    """A custom admin interface for User instances."""
+
+    readonly_fields = [
+        'last_login',
+        'date_joined',
+    ]
+
+    def get_form(self, request, obj=None, **kwargs):
+        """
+        Restrict the fields that staff can change.
+
+        For more on the why and how of this see https://realpython.com/manage-users-in-django-admin/
+        """
+        form = super().get_form(request, obj, **kwargs)
+        is_superuser = request.user.is_superuser
+        disabled_fields = set()  # type: Set[str]
+
+        if not is_superuser:
+            disabled_fields |= {
+                # Prevent non-superusers from changing usernames
+                'username',
+                # Prevent non-superusers from making a user staff or 
+                # a superuser
+                'is_staff',
+                'is_superuser',
+                # Prevent non-superusers from granting permissions to 
+                # specific users or groups
+                'user_permissions',
+                'groups'
+            }
+
+        for f in disabled_fields:
+            if f in form.base_fields:
+                form.base_fields[f].disabled = True
+
+        return form
+
+    def save_related(self, request, form, formsets, change):
+        """
+        Ensure that staff, and only staff, are members of the "Staff" permissions group.
+
+        This does not grant any permissions to the staff group.
+        That is left to the `admin` user to manage via the admin interface.
+        """
+        instance = form.instance
+        if instance.is_staff and instance.groups.filter(name='Staff').count() == 0:
+            group, created = Group.objects.get_or_create(name='Staff')
+            instance.groups.add(group)
+        elif not instance.is_staff and instance.groups.filter(name='Staff').count() > 0:
+            group = Group.objects.get(name='Staff')
+            instance.groups.remove(group)

--- a/director/users/apps.py
+++ b/director/users/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class UsersConfig(AppConfig):
+    name = 'users'


### PR DESCRIPTION
This is done with the view to us `is_staff` users using the Django admin interface more to manage issues (e.g. duplicate accounts, project settings etc) without having to log in as a super user. It removes some of the risks associated with making changes to user instances.