### PR TITLE
chore: typo fixes and node_type refactor

### DIFF
--- a/director/projects/api/views/nodes.py
+++ b/director/projects/api/views/nodes.py
@@ -1,6 +1,6 @@
-from typing import Optional
 import json
 import secrets
+from typing import Optional
 
 from django.conf import settings
 from django.shortcuts import get_object_or_404
@@ -18,13 +18,13 @@ from rest_framework.exceptions import NotAuthenticated, PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from lib.conversion_types import ConversionFormatId
 from lib.converter_facade import (
     ConverterFacade,
     ConverterIo,
     ConverterIoType,
     ConverterContext,
 )
-from lib.conversion_types import ConversionFormatId
 from projects.models import Node
 from projects.views.mixins import ProjectPermissionsMixin, ProjectPermissionType
 
@@ -241,14 +241,14 @@ def node_type(node) -> str:
         return "Null"
     if isinstance(node, bool):
         return "Boolean"
-    if isinstance(node, int) or isinstance(node, float):
+    if isinstance(node, (int, float)):
         return "Number"
     if isinstance(node, str):
         return "Text"
-    if isinstance(node, list) or isinstance(node, tuple):
+    if isinstance(node, (list, tuple)):
         return "Array"
     if isinstance(node, dict):
-        node_type = node.get("type")
-        if node_type is not None:
-            return node_type
+        type_name = node.get("type")
+        if type_name is not None:
+            return type_name
     return "Object"

--- a/director/urls_api.py
+++ b/director/urls_api.py
@@ -1,7 +1,7 @@
 """
 Module for defining all API URLs.
 
-This needs to be a module sparate from `urls.py` so that it can be referrred to
+This needs to be a module separate from `urls.py` so that it can be referred to
 in `general/api/views/docs.py` as the module from which the API schema is
 generated.
 """


### PR DESCRIPTION
Just noticed these when I was looking around, thought I'd quickly fix.

Renamed the variable `node_type` inside the `node_type` function. It's not good to shadow outer names inside a function. I would have preferred to rename the function to `get_node_type` for "function is verb" naming style but that would have been a much bigger change, so I did not. I also wanted to keep it consistent with the naming of the typescript implementation.

We do include `stencila.schema` as a requirement so this function could be implemented there for consistency.

I also updated the use of `isinstance` as it can take a list/tuple as its second arg and returns true if the value is any of those types.

Also fixed a couple of typos.

