### PR TITLE
Add monitor service

### DIFF
--- a/.config
+++ b/.config
@@ -22,3 +22,6 @@ DJANGO_API_BASIC_AUTH=true
 # them in the containers env var list.
 DJANGO_GS_PROJECT_ID=
 DJANGO_GS_BUCKET_NAME=
+
+# Used by `router` to reverse proxy `monitor`
+MONITOR_URL=http://monitor:9090

--- a/broker/Dockerfile
+++ b/broker/Dockerfile
@@ -2,3 +2,5 @@ FROM rabbitmq:3.8-management
 
 ENV RABBITMQ_DEFAULT_VHOST stencila
 ENV RABBITMQ_DEFAULT_USER stencila
+
+RUN rabbitmq-plugins enable rabbitmq_prometheus

--- a/broker/README.md
+++ b/broker/README.md
@@ -1,10 +1,10 @@
 # Stencila Hub Broker
 
-### Putpose
+## Purpose
 
-The `broker` is the mediator between task producers, such as the `director` and the `scheduler` services, and `worker`s, the task consumers. To initiate a task, a producer sends a message to the `broker`'s queue, which the `broker` then delivers to a `worker`.
+The `broker` is the mediator between task producers, such as the `director`, and `worker`s, the task consumers. To initiate a task, a producer sends a message to the `broker`'s queue, which the `broker` then delivers to a `worker`.
 
-### Solution
+## Solution
 
 We use RabbitMQ because it allows for [multi-tenancy via virtual hosts](https://www.rabbitmq.com/vhosts.html). This allows accounts to provide their own    workers by connecting to their own `vhost` on the broker.
 
@@ -12,6 +12,6 @@ The `stencila/hub-broker` Docker image is currently just a simple `FROM rabbitmq
 
 Instead of self hosting `stencila/hub-broker` a RabbitMQ-as-a-service service, such as https://www.cloudamqp.com/ could be used.
 
-### Alternatives
+## Alternatives
 
 Celery [supports several brokers](https://docs.celeryproject.org/en/latest/getting-started/brokers/index.html). Initially we used [Redis](https://redis.io/) because of it's ease of setup.

--- a/director/lib/constants.py
+++ b/director/lib/constants.py
@@ -15,10 +15,10 @@ class UrlRoot(enum.Enum):
     debug = "debug"
     favicon = "favicon.ico"
     ie_unsupported = "ie-unsupported"
+    internal = "internal"
     me = "me"
     open = "open"
     projects = "projects"
-    test = "test"
 
 
 class AccountUrlRoot(enum.Enum):

--- a/director/requirements.txt
+++ b/director/requirements.txt
@@ -13,6 +13,7 @@ django-filter==2.2.0
 django-intercom==0.1.3
 django-jsonfallback==2.1.2
 django-polymorphic==2.1.2
+django-prometheus==2.0.0
 django-rest-knox==4.1.0
 django-sendgrid-v5==0.8.1
 django-storages==1.7.2

--- a/director/settings.py
+++ b/director/settings.py
@@ -95,6 +95,7 @@ class Prod(Configuration):
         "django_celery_beat",
         "django_filters",
         "django_intercom",
+        "django_prometheus",
         "djstripe",
         # Our apps
         # Uses dotted paths to AppConfig subclasses as
@@ -107,6 +108,7 @@ class Prod(Configuration):
     ]
 
     MIDDLEWARE = [
+        "django_prometheus.middleware.PrometheusBeforeMiddleware",
         "lib.middleware.ie_detect_middleware",
         "django.middleware.security.SecurityMiddleware",
         "django.contrib.sessions.middleware.SessionMiddleware",
@@ -115,6 +117,7 @@ class Prod(Configuration):
         "django.contrib.auth.middleware.AuthenticationMiddleware",
         "django.contrib.messages.middleware.MessageMiddleware",
         "django.middleware.clickjacking.XFrameOptionsMiddleware",
+        "django_prometheus.middleware.PrometheusAfterMiddleware",
     ]
 
     ROOT_URLCONF = "urls"

--- a/director/urls.py
+++ b/director/urls.py
@@ -19,10 +19,11 @@ about_urls = [
     path("help/", views.HelpView.as_view(), name="help"),
 ]
 
-test_urls = [
-    path("403/", views.Test403View.as_view()),
-    path("404/", views.Test404View.as_view()),
-    path("500/", views.Test500View.as_view()),
+internal_urls = [
+    path("", include("django_prometheus.urls")),
+    path("test/403/", views.Test403View.as_view()),
+    path("test/404/", views.Test404View.as_view()),
+    path("test/500/", views.Test500View.as_view()),
 ]
 
 urlpatterns = [
@@ -52,8 +53,8 @@ urlpatterns = [
     path(UrlRoot.open.value + "/", include("stencila_open.urls")),
     # Projects App
     path(UrlRoot.projects.value + "/", include("projects.urls")),
-    # Testing errors
-    path(UrlRoot.test.value + "/", include(test_urls)),
+    # Internal URLs
+    path(UrlRoot.internal.value + "/", include(internal_urls)),
     # Custom Roots (they start with a slug)
     path("<slug:account_name>/", include("accounts.slug_urls")),
 ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,6 +19,7 @@ services:
       - .config
     depends_on:
       - director
+      - monitor
 
   director:
     build: ./director
@@ -45,6 +46,7 @@ services:
     image: stencila/hub-broker
     ports:
       - "5672:5672"
+      - "15692:15692"
     env_file:
       - .secrets
 
@@ -73,3 +75,15 @@ services:
       - .secrets
     depends_on:
       - broker
+
+  monitor:
+    build: ./monitor
+    image: stencila/hub-monitor
+    ports:
+      - "9090:9090"
+    volumes:
+      - monitor:/prometheus
+
+volumes:
+  monitor:
+    

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,9 @@
 # This docker-compose file is intended for development and testing.
-# However, it is also used as a basis for Kubernetes deployments.
-# Consequently, some properties have been added to improve conversion to 
-# Kubernetes configs when using Kompose.
+# 
+# It is, however, also used as a basis for Kubernetes deployments.
+# Consequently, some naming conventions and additional properties 
+# are used to improve conversion when using Kompose.
+# See https://github.com/kubernetes/kompose/blob/master/docs/user-guide.md#labels
 
 version: "3.6"
 
@@ -79,6 +81,8 @@ services:
   monitor:
     build: ./monitor
     image: stencila/hub-monitor
+    labels:
+      kompose.volume.size: 10Gi
     ports:
       - "9090:9090"
     volumes:

--- a/monitor/Dockerfile
+++ b/monitor/Dockerfile
@@ -1,0 +1,9 @@
+FROM prom/prometheus
+
+ADD prometheus.yml /etc/prometheus/
+
+CMD [ \
+  "--config.file=/etc/prometheus/prometheus.yml", \
+  "--storage.tsdb.path=/prometheus", \
+  "--web.external-url=http://localhost:9090/internal/monitor" \
+]

--- a/monitor/Dockerfile
+++ b/monitor/Dockerfile
@@ -5,5 +5,7 @@ ADD prometheus.yml /etc/prometheus/
 CMD [ \
   "--config.file=/etc/prometheus/prometheus.yml", \
   "--storage.tsdb.path=/prometheus", \
+  "--storage.tsdb.retention.size=8GB", \
+  "--storage.tsdb.retention.time=15d", \
   "--web.external-url=http://localhost:9090/internal/monitor" \
 ]

--- a/monitor/Makefile
+++ b/monitor/Makefile
@@ -1,0 +1,7 @@
+# Build Docker image
+build:
+	docker build --tag stencila/hub-monitor .
+
+# Run Docker image
+run: build
+	docker run --rm --network=host stencila/hub-monitor

--- a/monitor/README.md
+++ b/monitor/README.md
@@ -10,12 +10,19 @@ We use [Prometheus](https://prometheus.io/), a popular open-source application m
 
 Other services use so called "exporters" to expose metrics that Prometheus periodically scrapes, usually from the `/metrics` endpoint. For example, the `director` uses the `django_prometheus` Python package as an exporter and the `broker` uses the `rabbitmq_prometheus` plugin.
 
-Prometheus exposes a simple tool for visualization of metrics at http://localhost:9090/graph. For example, a [graph of the `up` metric for each of the services monitored](http://localhost:9090/graph?g0.range_input=1h&g0.expr=up&g0.tab=0). The `router` provides a reverse proxy to this tool at `/internal/monitor/graph`.
+Prometheus exposes a simple tool for visualization of metrics at http://localhost:9090/graph. For example, a graph of the `up` metric for each of the services monitored:
 
-Prometheus also exposes a HTTP API which can be queried to obtain time series of current values of metrics e.g. http://localhost:9090/internal/monitor/api/v1/query?query=up
 
-http://localhost:9090/api/v1/query_range?query=up&start=1588618000&end=1588619900&step=15
+http://localhost:9090/internal/monitor/graph?g0.range_input=1h&g0.expr=up&g0.tab=0
 
+
+Prometheus also exposes a HTTP API which can be queried to obtain time series of current values of metrics e.g. 
+
+
+http://localhost:9090/internal/monitor/api/v1/query?query=up
+
+
+The `router` provides a reverse proxy to the `monitor`'s graph interface and API at `/internal/monitor`.
 
 ## Alternatives
 

--- a/monitor/README.md
+++ b/monitor/README.md
@@ -1,0 +1,22 @@
+# Stencila Hub Monitor
+
+## Purpose
+
+The `monitor` is the Hub's application monitoring service. It collects and stores metrics on the health of the other services in the Hub (and on its self). Time series of these metrics can be queried and displayed.
+
+## Solution
+
+We use [Prometheus](https://prometheus.io/), a popular open-source application monitoring project orignally developed at SoundCloud.
+
+Other services use so called "exporters" to expose metrics that Prometheus periodically scrapes, usually from the `/metrics` endpoint. For example, the `director` uses the `django_prometheus` Python package as an exporter and the `broker` uses the `rabbitmq_prometheus` plugin.
+
+Prometheus exposes a simple tool for visualization of metrics at http://localhost:9090/graph. For example, a [graph of the `up` metric for each of the services monitored](http://localhost:9090/graph?g0.range_input=1h&g0.expr=up&g0.tab=0). The `router` provides a reverse proxy to this tool at `/internal/monitor/graph`.
+
+Prometheus also exposes a HTTP API which can be queried to obtain time series of current values of metrics e.g. http://localhost:9090/internal/monitor/api/v1/query?query=up
+
+http://localhost:9090/api/v1/query_range?query=up&start=1588618000&end=1588619900&step=15
+
+
+## Alternatives
+
+Prometheus has a detailed [comparison with alternatives](https://prometheus.io/docs/introduction/comparison/).

--- a/monitor/prometheus.yml
+++ b/monitor/prometheus.yml
@@ -1,0 +1,20 @@
+
+global:
+  scrape_interval:     15s
+  evaluation_interval: 15s
+
+scrape_configs:
+
+  - job_name: monitor
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: director
+    metrics_path: /internal/metrics
+    static_configs:
+      - targets: ['director:8000']
+
+  - job_name: broker
+    static_configs:
+      - targets: ['broker:15692']
+

--- a/monitor/prometheus.yml
+++ b/monitor/prometheus.yml
@@ -6,6 +6,7 @@ global:
 scrape_configs:
 
   - job_name: monitor
+    metrics_path: /internal/monitor/metrics
     static_configs:
       - targets: ['localhost:9090']
 

--- a/router/Makefile
+++ b/router/Makefile
@@ -6,4 +6,5 @@ build:
 run: build
 	docker run --rm --network=host \
 		-e DIRECTOR_HOST=localhost:8000 \
+		-e MONITOR_URL=http://localhost:9090 \
 		stencila/hub-router

--- a/router/entrypoint.sh
+++ b/router/entrypoint.sh
@@ -7,7 +7,8 @@
 set -eu
 
 : "${DIRECTOR_HOST:?Env var DIRECTOR_HOST must be set and non-empty}"
+: "${MONITOR_URL:?Env var MONITOR_URL must be set and non-empty}"
 
-envsubst '${DIRECTOR_HOST}' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
+envsubst '${DIRECTOR_HOST} ${MONITOR_URL}' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
 
 exec "$@"

--- a/router/nginx.conf
+++ b/router/nginx.conf
@@ -18,6 +18,12 @@ server {
     internal;
   }
 
+  # Access to the monitor's HTTP API and graphing 
+  # interface
+  location /internal/monitor {
+    proxy_pass ${MONITOR_URL};
+  }
+
   location @jobs-connect {
     # Internal proxy URL to jobs to be used with `X-Accel-Redirect`
     # to restrict access.


### PR DESCRIPTION
As the `monitor/README.md` says...

## Purpose

The `monitor` is the Hub's application monitoring service. It collects and stores metrics on the health of the other services in the Hub (and on its self). Time series of these metrics can be queried and displayed.

## Solution

We use [Prometheus](https://prometheus.io/), a popular open-source application monitoring project orignally developed at SoundCloud.

Other services use so called "exporters" to expose metrics that Prometheus periodically scrapes, usually from the `/metrics` endpoint. For example, the `director` uses the `django_prometheus` Python package as an exporter and the `broker` uses the `rabbitmq_prometheus` plugin.

Prometheus exposes a simple tool for visualization of metrics at http://localhost:9090/graph. For example, a [graph of the `up` metric for each of the services monitored](http://localhost:9090/graph?g0.range_input=1h&g0.expr=up&g0.tab=0). The `router` provides a reverse proxy to this tool at `/internal/monitor/graph`.

Prometheus also exposes a HTTP API which can be queried to obtain time series of current values of metrics e.g. http://localhost:9090/internal/monitor/api/v1/query?query=up

## Alternatives

Prometheus has a detailed [comparison with alternatives](https://prometheus.io/docs/introduction/comparison/).
