### PR TITLE
feat(Manager): Add a user search

### DIFF
--- a/manager/manager/static/sass/styles.scss
+++ b/manager/manager/static/sass/styles.scss
@@ -65,7 +65,7 @@ $footer-padding: 2rem 3rem 0.1rem;
 
 // @import "../../../node_modules/bulma/sass/components/breadcrumb.sass";
 // @import "../../../node_modules/bulma/sass/components/card.sass";
-// @import "../../../node_modules/bulma/sass/components/dropdown.sass";
+@import "../../../node_modules/bulma/sass/components/dropdown.sass";
 @import "../../../node_modules/bulma/sass/components/level.sass";
 // @import "../../../node_modules/bulma/sass/components/list.sass";
 // @import "../../../node_modules/bulma/sass/components/media.sass";

--- a/manager/users/api/views/users_tests.py
+++ b/manager/users/api/views/users_tests.py
@@ -27,7 +27,7 @@ class UserAPIViewsTests(DatabaseTestCase):
         authed = self.list_users(self.ada)
         assert authed.data == anon.data
 
-        searched = self.list_users(None, data={"q": "cam"})
+        searched = self.list_users(None, data={"search": "cam"})
         users = searched.data["results"]
         assert len(users) == 1
         assert users[0]["username"] == "cam"

--- a/manager/users/templates/users/_search.html
+++ b/manager/users/templates/users/_search.html
@@ -1,0 +1,48 @@
+{% comment %}
+A search field for users.
+
+Allows interactive searching for users.
+Intended to be used in forms that require a user to be specified
+e.g. adding another user to a team, or a project.
+
+Inspired by Github's user search field (amongst others).
+{% endcomment %}
+<div id="user-search" class="dropdown is-active">
+  <div class="dropdown-trigger">
+    <div class="field">
+      <div class="control has-icons-left has-icons-right">
+        <input
+          class="input"
+          type="text" 
+          name="search"
+          placeholder="Search by username, full name, or email" 
+          hx-trigger="keyup changed delay:500ms" 
+          hx-get="/api/users"
+          hx-indicator="#user-search .htmx-indicator"
+          hx-target="#user-search .dropdown-menu"
+        >
+        <span class="icon is-small is-left">
+          <i class="fas fa-search"></i>
+        </span>
+        <span class="icon is-small is-right htmx-indicator">
+          <i class="fa fa-spinner fa-pulse"></i>
+        </span>
+      </div>
+    </div>
+    {# A hidden input to hold the value of the selected user. Will be submitted with the enclosing form. #}
+    <input type="hidden" name="user">
+  </div>
+  <div class="dropdown-menu"></div>
+  <script>
+    var $search = document.querySelector('#user-search')
+    // Add query parameters to search
+    $search.querySelector('input[name=search]').addEventListener('configRequest.htmx', function(event) {
+        event.detail.parameters['limit'] = '30';
+        event.detail.parameters['html'] = 'users/_search_results.html';
+      });
+    // Update the `input[name=user]` when a dropdown item is selected
+    $search.querySelector('.dropdown-menu').addEventListener('click', function(event) {
+        $search.querySelector('input[name=user]').value = event.target.getAttribute('data-id')
+      });
+  </script>
+</div>

--- a/manager/users/templates/users/_search.html
+++ b/manager/users/templates/users/_search.html
@@ -7,7 +7,7 @@ e.g. adding another user to a team, or a project.
 
 Inspired by Github's user search field (amongst others).
 {% endcomment %}
-<div id="user-search" class="dropdown is-active">
+<div id="user-search" class="dropdown is-hoverable">
   <div class="dropdown-trigger">
     <div class="field">
       <div class="control has-icons-left has-icons-right">

--- a/manager/users/templates/users/_search.html
+++ b/manager/users/templates/users/_search.html
@@ -42,7 +42,9 @@ Inspired by Github's user search field (amongst others).
       });
     // Update the `input[name=user]` when a dropdown item is selected
     $search.querySelector('.dropdown-menu').addEventListener('click', function(event) {
-        $search.querySelector('input[name=user]').value = event.target.getAttribute('data-id')
+        var item = htmx.closest(event.target, '.dropdown-item')
+        $search.querySelector('input[name=search]').value = item.getAttribute('data-username')
+        $search.querySelector('input[name=user]').value = item.getAttribute('data-id')
       });
   </script>
 </div>

--- a/manager/users/templates/users/_search_results.html
+++ b/manager/users/templates/users/_search_results.html
@@ -1,0 +1,18 @@
+{% comment %}
+Display user search results.
+
+Intended to be used with `users/_search.html`
+for displaying user search results.
+{% endcomment %}
+<div class="dropdown-content">
+  {% for user in queryset %}
+    <div class="dropdown-item" data-id="{{ user.id }}">
+      <strong>{{ user.username }}</strong>&nbsp;&nbsp;
+      <span>{{ user.first_name }} {{ user.last_name }}<span>
+    </div>
+  {% empty %}
+    <div class="dropdown-item">
+      Sorry, could not find a matching user.
+    </div>
+  {% endfor %}
+</div>

--- a/manager/users/templates/users/_search_results.html
+++ b/manager/users/templates/users/_search_results.html
@@ -6,7 +6,7 @@ for displaying user search results.
 {% endcomment %}
 <div class="dropdown-content">
   {% for user in queryset %}
-    <div class="dropdown-item" data-id="{{ user.id }}">
+    <div class="dropdown-item" data-id="{{ user.id }}" data-username="{{ user.username }}">
       <strong>{{ user.username }}</strong>&nbsp;&nbsp;
       <span>{{ user.first_name }} {{ user.last_name }}<span>
     </div>


### PR DESCRIPTION
This adds a user search field intended to replace the Buefy based one [here](https://github.com/stencila/hub/blob/master/director/assets/js/user-search.js). This is not a high priority (although we do need it for teams and project members) but was done now as a spike to see how well an approach using `htmx` and HTML API responses would work for this more complicated use case.

I'm pretty happy with how quick it was to implement this. Although it could do with some tweaks to the UX. You can try it out standalone at http://localhost:8000/stencila/render/?wrap=users/_search.html

![Peek 2020-06-03 17-15](https://user-images.githubusercontent.com/1152336/83598488-f1104a00-a5bd-11ea-9a48-06a182b0d4aa.gif)
