### PR TITLE
Manager: misc refinements

### DIFF
--- a/manager/manager/static/sass/styles.scss
+++ b/manager/manager/static/sass/styles.scss
@@ -150,6 +150,13 @@ body {
     font-size: 0.75rem;
   }
 
+  .control.has-icons-left .input.is-small-mobile ~ .icon,
+  .control.has-icons-left .select.is-small-mobile ~ .icon,
+  .control.has-icons-right .input.is-small-mobile ~ .icon,
+  .control.has-icons-right .select.is-small-mobile ~ .icon {
+    font-size: 0.75rem;
+  }
+
   .button.is-fullwidth-mobile {
     display: flex;
     width: 100%;

--- a/manager/projects/templates/projects/sources/_sources.html
+++ b/manager/projects/templates/projects/sources/_sources.html
@@ -4,12 +4,13 @@
 <div class="level is-mobile">
   <div class="level-left">
     <div class="level-item">
+      {% comment %}
       <form class="field">
         <label class="is-sr-only" for="file-filter">
           {% trans "File filter" %}
         </label>
         <div class="control has-icons-left has-icons-right">
-          <input id="file-filter" class="input" type="text" name="search"
+          <input id="file-filter" disabled class="input is-small-mobile" type="text" name="search"
                  placeholder="{% trans "Filter files by name…" %}" hx-trigger="keyup changed delay:500ms"
                  hx-get="{% url 'api-projects-sources-list' project.id %}"
                  hx-template="projects/sources/_source_list.html" hx-indicator="#file-filter-indicator"
@@ -22,6 +23,7 @@
           </span>
         </div>
       </form>
+      {% endcomment %}
     </div>
   </div>
 

--- a/manager/scripts/create_page_snaps.py
+++ b/manager/scripts/create_page_snaps.py
@@ -251,9 +251,6 @@ async def main():
                     dict(
                         content="""
                     .snipTarget {
-                        background-color: white;
-                        margin: -7px;
-                        padding: 7px;
                         position: relative;
                         z-index: 300;
                     }


### PR DESCRIPTION
- fix(CSS): Reduce icon size for is-small-mobile controls
- feat(Sources): Hide source filter until working
- fix(Snaps): Avoid breaking element styles
  - Some generated screenshots were mangling the elements being captured (namely toggle component). Was there a reason for adding the `margin/padding: -7px` CSS @nokome? The screenshots generated with these changes in this PR  seem to look good