### PR TITLE
fix(Projects): Temporarily disable table row links due to bug

### DIFF
--- a/manager/manager/static/sass/projects/index.scss
+++ b/manager/manager/static/sass/projects/index.scss
@@ -64,7 +64,7 @@
 
 .job-list--id,
 a.job-list--id {
-  @extend .expand-link;
+  // @extend .expand-link;
   color: $grey;
   font-size: 0.825rem;
   letter-spacing: 1px;

--- a/manager/manager/static/sass/projects/sources/index.scss
+++ b/manager/manager/static/sass/projects/sources/index.scss
@@ -2,6 +2,6 @@
   width: 1em;
 }
 
-a.table-icon-label {
-  @extend .expand-link;
-}
+// a.table-icon-label {
+//   @extend .expand-link;
+// }

--- a/manager/projects/templates/projects/snapshots/_list.html
+++ b/manager/projects/templates/projects/snapshots/_list.html
@@ -37,7 +37,7 @@ A partial for displaying a list of snapshots.
         </td>
         <td class="source-table--file-type pr-0 is-vcentered">
           <a href="{% url 'ui-projects-snapshots-retrieve' snapshot.project.account.name snapshot.project.name snapshot.id %}"
-             class="button is-outlined is-small expand-link">
+             class="button is-outlined is-small">
             {% trans "Details" %}
           </a>
         </td>

--- a/manager/projects/templates/projects/snapshots/_list.html
+++ b/manager/projects/templates/projects/snapshots/_list.html
@@ -9,7 +9,7 @@ A partial for displaying a list of snapshots.
   {% if snapshots %}
   <table class="table is-fullwidth is-striped is-hoverable">
     <thead>
-      <tr class="table-header">
+      <tr class="table-header has-text-left">
         <th>
           {% trans "Created" %}
         </th>


### PR DESCRIPTION
`overflow: hidden` doesn't work for table-row elements causing the row link to take on the size of the full table, so disabling this until a workaround can be added.