### PR TITLE
Change the way that missing tokens are handled

### DIFF
--- a/manager/projects/models/sources.py
+++ b/manager/projects/models/sources.py
@@ -12,7 +12,7 @@ from django.utils import timezone
 from polymorphic.managers import PolymorphicManager
 from polymorphic.models import PolymorphicModel
 
-from jobs.models import Job, JobMethod, JobStatus
+from jobs.models import Job, JobMethod
 from manager.media import private_storage
 from projects.models.projects import Project
 from users.models import User
@@ -320,7 +320,6 @@ class Source(PolymorphicModel):
 
         Creates a job, dispatches it and add it to the sources `jobs` list.
         """
-
         source = self.to_address()
         source["token"] = self.authorization_token(user)
 
@@ -328,9 +327,7 @@ class Source(PolymorphicModel):
             project=self.project,
             creator=user,
             method="pull",
-            params=dict(
-                source=source, project=self.project.id, path=self.path
-            )
+            params=dict(source=source, project=self.project.id, path=self.path),
         )
         job.dispatch()
         self.jobs.add(job)

--- a/manager/projects/models/sources.py
+++ b/manager/projects/models/sources.py
@@ -320,26 +320,19 @@ class Source(PolymorphicModel):
 
         Creates a job, dispatches it and add it to the sources `jobs` list.
         """
+
+        source = self.to_address()
+        source["token"] = self.authorization_token(user)
+
         job = Job.objects.create(
             project=self.project,
             creator=user,
             method="pull",
             params=dict(
-                source=self.to_address(), project=self.project.id, path=self.path
-            ),
+                source=source, project=self.project.id, path=self.path
+            )
         )
-
-        try:
-            token = self.authorization_token(user)
-            if token:
-                job.params["source"]["token"] = token
-        except Exception as exc:
-            job.status = JobStatus.FAILURE.name
-            job.error = str(exc)
-            job.save()
-        else:
-            job.dispatch()
-
+        job.dispatch()
         self.jobs.add(job)
         return job
 

--- a/manager/users/socialaccount/tokens.py
+++ b/manager/users/socialaccount/tokens.py
@@ -62,7 +62,8 @@ def get_user_github_token(user: User) -> Optional[str]:
     """
     Get a user's Github token.
     """
-    return get_user_social_token(user, ProviderId.github, raise_exception=True).token
+    token = get_user_social_token(user, ProviderId.github)
+    return token.token if token else None
 
 
 def get_user_google_token(user: User) -> Optional[str]:
@@ -70,4 +71,5 @@ def get_user_google_token(user: User) -> Optional[str]:
     Get a user's Google token and refresh it if necessary.
     """
     # TODO: check and refresh if needed
-    return get_user_social_token(user, ProviderId.google, raise_exception=True).token
+    token = get_user_social_token(user, ProviderId.google)
+    return token.token if token else None

--- a/worker/jobs/pull/gdoc.py
+++ b/worker/jobs/pull/gdoc.py
@@ -10,8 +10,8 @@ def pull_gdoc(source: dict, project: str, path: str) -> List[str]:
     """
     Pull google doc using given user token
     """
-    assert "doc_id" in source, "source must have a doc_id"
-    assert "token" in source, "source must include a token"
+    assert source.get("doc_id"), "A document id is required"
+    assert source.get("token"), "A Google authentication token is required"
 
     credentials = GoogleCredentials(
         source["token"], None, None, None, None, None, "Stencila Hub Client",

--- a/worker/jobs/pull/gdoc_test.py
+++ b/worker/jobs/pull/gdoc_test.py
@@ -19,7 +19,7 @@ def test_missing_token(tempdir):
     doc_id = "1BW6MubIyDirCGW9Wq-tSqCma8pioxBI6VpeLyXn5mZA"
     with pytest.raises(AssertionError) as excinfo:
         pull_gdoc(dict(doc_id=doc_id), tempdir.path, "{}.json".format(doc_id))
-    assert "source must include a token" in str(excinfo.value)
+    assert "A Google authentication token is required" in str(excinfo.value)
 
 
 @pytest.mark.vcr

--- a/worker/jobs/pull/gdrive.py
+++ b/worker/jobs/pull/gdrive.py
@@ -22,10 +22,8 @@ def pull_gdrive(source: dict, project: str, path: str) -> List[str]:
     """
     Pull a google drive folder
     """
-    assert "folder_id" in source, "source must have a folder_id"
-    assert (
-        "token" in source and source["token"] is not None
-    ), "source must include a token"
+    assert source.get("folder_id"), "A folder id is required"
+    assert source.get("token"), "A Google authentication token is required"
 
     credentials = GoogleCredentials(
         source["token"], None, None, None, None, None, "Stencila Hub Client",

--- a/worker/jobs/pull/github_test.py
+++ b/worker/jobs/pull/github_test.py
@@ -4,22 +4,16 @@ import pytest
 from .github import pull_github
 
 
-def test_missing_token(tempdir):
-    with pytest.raises(AssertionError) as excinfo:
-        pull_github(dict(repo="stencila/hub", subpath=""), tempdir.path, "")
-    assert "source must include a token" in str(excinfo.value)
-
-
 @pytest.mark.vcr
 def test_public_repo(tempdir):
-    source = dict(repo="stencila/test", subpath="sub", token=None)
+    source = dict(repo="stencila/test", subpath="sub")
     pull_github(source, tempdir.path, "")
     assert os.path.exists(os.path.join(tempdir.path, "README.md"))
 
 
 @pytest.mark.vcr
 def test_subdirectory(tempdir):
-    source = dict(repo="stencila/test", subpath="", token=None)
+    source = dict(repo="stencila/test", subpath="")
     subdir = "a/very/very/deep/sub/directory"
     pull_github(source, os.path.join(tempdir.path, subdir), "")
     for expected in (
@@ -33,7 +27,7 @@ def test_subdirectory(tempdir):
 
 @pytest.mark.vcr
 def test_single_file(tempdir):
-    source = dict(repo="stencila/test", subpath="sub/README.md", token=None)
+    source = dict(repo="stencila/test", subpath="sub/README.md")
     pull_github(source, tempdir.path, "sub_README.md")
     assert not os.path.exists(os.path.join(tempdir.path, "README.md"))
     assert not os.path.exists(os.path.join(tempdir.path, "sub/README.md"))


### PR DESCRIPTION
Previously we raised an exception if there was no auth token for a source (as is usually the case in development). This PR defers that exception raising to the worker, for example so that it can try to get a public Github repo without a token instead of always failing. This is also advantageous in that it makes job error handling more uniform.

This means more of the demo sources can be pulled, but also that occasionally an (expected) Github rate limit error will happen. 

![image](https://user-images.githubusercontent.com/1152336/85808989-9af08a00-b7aa-11ea-83c6-bd49eea594e5.png)
