### PR TITLE
feat(Jobs): Expose sub-jobs in line with parent Job

### DIFF
--- a/manager/manager/static/sass/projects/index.scss
+++ b/manager/manager/static/sass/projects/index.scss
@@ -46,7 +46,7 @@
       background-color: $white-bis;
     }
 
-    &:hover .job-list--item {
+    .job-list--item:hover {
       background-color: $white-ter;
     }
   }
@@ -81,6 +81,73 @@
   code {
     color: $text;
   }
+
+  .notification {
+    font-size: $size-7;
+  }
+}
+
+.job-list__sub-jobs {
+  border-left: 2px solid $grey-lighter;
+  position: relative;
+
+  &::before {
+    background-color: $white-ter;
+    border-radius: 9999px;
+    border: 2px solid $grey-lighter;
+    color: $text;
+    content: "\EF90";
+    font-family: remixicon!important;
+    font-size: 14px;
+    height: 28px;
+    left: -14px;
+    position: absolute;
+    text-align: center;
+    top: -14px;
+    width: 28px;
+    line-height: 24px;
+    z-index: 10;
+  }
+
+  &::after {
+    background-color: $white;
+    color: $text;
+    content: "Sub-Jobs";
+    font-size: $size-7;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    padding: 0 4px;
+    left: 20px;
+    position: absolute;
+    top: -6px;
+    font-weight: bold;
+    line-height: 1;
+    z-index: 10;
+  }
+
+  .job-list--item {
+    margin-left: 0;
+    position: relative;
+
+    &::before {
+      background-color: $white-ter;
+      border-radius: 9999px;
+      border: 2px solid $grey-lighter;
+      color: $text;
+      content: "";
+      font-family: remixicon!important;
+      font-size: 14px;
+      height: 8px;
+      left: -1px;
+      line-height: 4px;
+      position: absolute;
+      text-align: center;
+      top: 50%;
+      transform: translateX(-50%) translateY(-50%);
+      width: 8px;
+      z-index: 10;
+    }
+  }
 }
 
 .job-list--id,
@@ -95,9 +162,12 @@ a.job-list--id {
   display: flex;
   flex-wrap: wrap;
   font-size: 0.75rem;
-  text-transform: uppercase;
 
   & > span {
+    &:first-child:not(.job-list__creator) {
+      margin-left: -8px;
+    }
+
     &:not(:last-child):after {
       content: '·';
       display: inline-block;

--- a/manager/manager/static/sass/styles.scss
+++ b/manager/manager/static/sass/styles.scss
@@ -235,6 +235,10 @@ body {
     width: 0.01em !important;
   }
 
+  .is-inline-block-mobile {
+    display: inline-block;
+  }
+
   .width-full-mobile {
     width: 100%;
   }

--- a/manager/projects/templates/projects/jobs/_job_item.html
+++ b/manager/projects/templates/projects/jobs/_job_item.html
@@ -2,7 +2,7 @@
 
 <div class="columns is-relative my-0 py-0 {% if is_list_item %}job-list--item{% endif %}">
   <div class="column is-2">
-    <div>
+    <div class="is-inline-block-mobile">
       <div class="tag has-text-weight-bold">
         {{ job.method|title }}
       </div>
@@ -20,8 +20,10 @@
     {% endif %}
   </div>
   <div class="column">
+
     <div class="job-list--meta mb-2">
-      <span>
+      {% if show_sub_jobs == None %}
+      <span class="job-list__creator">
         <span class="icon is-small is-vcentered pr-1">
           <img src="{{ job.creator.personal_account.image.small }}" role="presentation"></img>
         </span>
@@ -38,6 +40,7 @@
           {{ job.created|naturaltime }}
         </span>
       </span>
+      {% endif %}
 
       {% if job.runtime_formatted %}
       <span>
@@ -84,3 +87,9 @@
   </div>
   {% endif %}
 </div>
+
+{% if job.children.all and show_sub_jobs == True %}
+<div class="job-list__sub-jobs">
+  {% include "./_job_list.html" with jobs=job.children.all show_sub_jobs=True %}
+</div>
+{% endif %}

--- a/manager/projects/templates/projects/jobs/_job_list.html
+++ b/manager/projects/templates/projects/jobs/_job_list.html
@@ -1,0 +1,13 @@
+<ul class="job-list">
+  {% for job in jobs %}
+  {% if job.parent == None %}
+  <li>
+    {% include "./_job_item.html" with is_list_item=True %}
+  </li>
+  {% elif show_sub_jobs == True %}
+  <li>
+    {% include "./_job_item.html" with is_list_item=True is_sub_job=True %}
+  </li>
+  {% endif %}
+  {% endfor %}
+</ul>

--- a/manager/projects/templates/projects/jobs/_list.html
+++ b/manager/projects/templates/projects/jobs/_list.html
@@ -7,15 +7,7 @@ A partial for displaying a list of jobs.
 {% include "./_action_bar.html" %}
 
 {% if jobs %}
-<ul class="job-list">
-  {% for job in jobs %}
-  {% if job.parent == None %}
-  <li>
-    {% include "./_job_item.html" with is_list_item=True %}
-  </li>
-  {% endif %}
-  {% endfor %}
-</ul>
+{% include "./_job_list.html" %}
 {% else %}
 
 <div class="has-text-centered">

--- a/manager/projects/templates/projects/jobs/_retrieve.html
+++ b/manager/projects/templates/projects/jobs/_retrieve.html
@@ -32,11 +32,11 @@ in case the enclosing page want to use that data to trigger further events
   {% if job.children.all %}
   <hr />
 
-  <h2 class="title is-4">Sub-Jobs</h2>
+  <h2 class="title is-4">{% trans "Sub-Jobs" %}</h2>
   <ol class="job-list">
     {% for child in job.children.all %}
     <li>
-      {% include "./_job_item.html" with job=child is_list_item=True %}
+      {% include "./_job_item.html" with job=child is_list_item=True show_sub_jobs=True %}
     </li>
     {% endfor %}
   </ol>


### PR DESCRIPTION
When viewing a Job, this PR exposes the nested sub-Jobs inline to allow better comprehension of what's going on as well as easier identification of any errors.
There are further refinements which should be made around the top level information presented, links to parent Jobs when viewing a sub-Job, etc. but I feel these are best deferred till we get some real usage data and have time for design iterations.

Preview attached below:
![Screen Shot 2020-07-02 at 15 28 35](https://user-images.githubusercontent.com/1646307/86401877-f3c39500-bc78-11ea-8474-3846625ac9e3.png)
