### PR TITLE
Open dropdown menus for click events

### DIFF
--- a/manager/manager/static/js/src/dropdowns.js
+++ b/manager/manager/static/js/src/dropdowns.js
@@ -50,14 +50,11 @@ const attachDropdownHandlers = (dropdown) => {
     }, 100);
   };
 
-  const showEvents = ["mouseenter", "focus"];
+  const showEvents = ["click", "mouseenter", "focus"];
   const hideEvents = ["mouseleave", "blur"];
 
   showEvents.forEach((event) => {
     trigger.addEventListener(event, show);
-  });
-
-  showEvents.forEach((event) => {
     targetEl.addEventListener(event, cancelDestruction);
     dropdown.setAttribute("data-dropdown-hydrated", "true");
   });


### PR DESCRIPTION
This PR adds an event lister to dropdown menus to open them on `click` events.
This functionality is needed to program the Intercom Product Tours for features contained in dropdown menus.