### PR TITLE
fix(Accounts): Fix Plan Tier listing layout overflow

### DIFF
--- a/manager/accounts/templates/accounts/plan.html
+++ b/manager/accounts/templates/accounts/plan.html
@@ -1,5 +1,5 @@
 {% extends './base.html' %}
-{% load i18n stencila  %}
+{% load i18n stencila humanize %}
 
 {% block title %}{{ account.name }} {% trans "Plan" %}{% endblock %}
 
@@ -117,11 +117,11 @@
       </p>
     </div>
 
-    <ul class="columns pricing-table mt-4">
-      {% for tier in tiers %}
-      <li class="column pricing-table__item is-one-third">
-        <figure class="is-size-5">
-          <h2 class="is-size-6 has-text-centered">{{ tier.name }}</h2>
+    <ul class="columns is-multiline is-variable is-2 pricing-table mt-4">
+      {% for tier in tiers|dictsort:"job_runtime_month" %}
+      <li class="column is-one-third">
+        <figure class="is-size-5 pricing-table__item">
+          <h2 class="has-text-centered title is-4">{% trans tier.name %}</h2>
 
           <p>
             <span class="icon has-text-grey-light"><i class="ri-lock-line"></i></span>
@@ -172,9 +172,9 @@
           </p>
 
           <p>
-            <span class="icon has-text-grey-light"><i class="ri-timer-2-line"></i></span>
+            <span class="icon has-text-grey-light"><i class="ri-timer-line"></i></span>
             <span>
-              {{ tier.job_runtime_month }} {% trans "Job minutes" %}
+              {{ tier.job_runtime_month|intcomma }} {% trans "Job minutes" %}
             </span>
             <span class="icon has-text-grey-light has-tooltip-bottom has-tooltip-text-centered"
                   data-tooltip="{% trans fields.job_runtime_month.help_text %}">


### PR DESCRIPTION
Fixes horizontal layout when multiple tiers are available.

More refinements will be made in a future PR for addressing logic around which options should be shown to users (should we prevent `Waiting List` candidates from paying to upgrade their account? I suggest not), and need to add listing for Publisher/Enterprise account.

**Before**
<img width="1555" alt="Screenshot 2020-07-10 at 14 23 56@2x" src="https://user-images.githubusercontent.com/1646307/87186323-504a3400-c2b9-11ea-992a-7e12839d4653.png">

**After**
<img width="1495" alt="Screenshot 2020-07-10 at 14 24 03@2x" src="https://user-images.githubusercontent.com/1646307/87186337-550ee800-c2b9-11ea-85b1-bb862f291215.png">
