### PR TITLE
Reinstate /open

### DIFF
--- a/manager/README.md
+++ b/manager/README.md
@@ -1,6 +1,6 @@
 ## Develop
 
-### Local Development
+### Getting started
 
 Run the Django server using,
 
@@ -20,9 +20,23 @@ Some user interactions (e.g pulling and converting project sources) require `Job
 2. `make -C ../overseer run` to update the manager with data on workers and jobs
 3. `make -C ../worker run` to actually perform the jobs
 
+### Linting
+
+Four forms of code quality analysis are currently done: 
+
+- `make lint-format` runs [`black`](https://pypi.org/project/black/) for code formatting checking.
+
+- `make lint-code` runs [`flake8`](http://flake8.pycqa.org) for code style checking.
+
+- `make lint-types` runs [`mypy`](http://mypy-lang.org/) for static type checking.
+
+- `make lint-docs` runs [`pydocstyle`](http://www.pydocstyle.org) for checks on docstrings.
+
+Running `make lint` will perform all three checks.
+
 ### End-to-end test and page screenshots
 
-The script [`create_page_snaps.py`](scripts/create_page_snaps.py) will, for all of the `manager`'s pages  (well, almost all; it excludes admin pages etc),
+The script [`create_page_snaps.py`](scripts/create_page_snaps.py) will, for all of the `manager`'s pages  (well, almost all; it includes pages that are behind feature flags but excludes admin and some other pages),
 
 - Records the response status code, response time and number be database queries (useful as an end-to-end and performance test)
 

--- a/manager/accounts/models.py
+++ b/manager/accounts/models.py
@@ -158,6 +158,32 @@ class Account(models.Model):
 
         return super().save(*args, **kwargs)
 
+    # Methods to get "built-in" accounts
+    # Optimized for frequent access by use of caching.
+
+    @classmethod
+    def get_stencila_account(cls) -> "Account":
+        """
+        Get the Stencila account object.
+        """
+        if not hasattr(cls, "_stencila_account"):
+            cls._stencila_account = Account.objects.get(name="stencila")
+        return cls._stencila_account
+
+    @classmethod
+    def get_temp_account(cls) -> "Account":
+        """
+        Get the 'temp' account object.
+
+        This account owns all temporary projects.
+        For compatability with templates and URL resolution
+        it is easier and safer to use this temporary account
+        than it is to allow `project.account` to be null.
+        """
+        if not hasattr(cls, "_temp_account"):
+            cls._temp_account = Account.objects.get(name="temp")
+        return cls._temp_account
+
 
 def make_account_creator_an_owner(
     sender, instance: Account, created: bool, *args, **kwargs

--- a/manager/manager/api/helpers.py
+++ b/manager/manager/api/helpers.py
@@ -245,7 +245,7 @@ def filter_from_ident(
     If the identifier looks like an integer, then
     the filter has key `id`, otherwise `name`.
     """
-    if isinstance(value, str) and re.match(r"\d+", value):
+    if isinstance(value, str) and re.match(r"^\d+$", value):
         key = int_key
         value = int(value)
     else:
@@ -256,5 +256,10 @@ def filter_from_ident(
 
 
 def get_object_from_ident(cls, value: str):
-    """Get an object from an indentifier."""
+    """Get an object from an identifier."""
     return get_object_or_404(cls, **filter_from_ident(value))
+
+
+def get_help_text(cls, field: str) -> str:
+    """Get a model field help text."""
+    return cls._meta.get_field(field).help_text

--- a/manager/manager/helpers.py
+++ b/manager/manager/helpers.py
@@ -147,7 +147,7 @@ def should_send_message(
     request: HttpRequest, key: str, within=datetime.timedelta(minutes=60)
 ) -> bool:
     """
-    Should a message be sent to the user.
+    Determine if a message should be sent to the user.
 
     Checks the session to see whether a message with the same `key`
     was sent `within` the period.

--- a/manager/manager/helpers.py
+++ b/manager/manager/helpers.py
@@ -1,8 +1,11 @@
+import datetime
 import enum
 import re
+import time
 from typing import List, Optional, Tuple
 
 from django.db.models import Model, QuerySet
+from django.http import HttpRequest
 from django.template.defaultfilters import slugify
 
 
@@ -138,3 +141,26 @@ def unique_slugify(
         next += 1
 
     return slug
+
+
+def should_send_message(
+    request: HttpRequest, key: str, within=datetime.timedelta(minutes=60)
+) -> bool:
+    """
+    Should a message be sent to the user.
+
+    Checks the session to see whether a message with the same `key`
+    was sent `within` the period.
+    """
+    messages = request.session.get("messages")
+    if not messages:
+        request.session["messages"] = {key: time.time()}
+        return True
+
+    last = messages.get(key, 0)
+    if (time.time() - last) > within.total_seconds():
+        request.session["messages"][key] = time.time()
+        request.session.modified = True
+        return True
+
+    return False

--- a/manager/manager/paths.py
+++ b/manager/manager/paths.py
@@ -14,6 +14,7 @@ class RootPaths(enum.Enum):
     api = "api"
     favicon = "favicon.ico"
     me = "me"
+    open = "open"
     orgs = "orgs"
     projects = "projects"
     users = "users"

--- a/manager/manager/settings.py
+++ b/manager/manager/settings.py
@@ -314,6 +314,22 @@ class Prod(Configuration):
             "knox.auth.TokenAuthentication",
             "rest_framework.authentication.SessionAuthentication",
         ],
+        "DEFAULT_THROTTLE_CLASSES": [
+            "rest_framework.throttling.AnonRateThrottle",
+            "rest_framework.throttling.UserRateThrottle",
+        ],
+        "DEFAULT_THROTTLE_RATES": {
+            # These rates only apply to `/api` endpoints. They
+            # do not include "pseudo-requests" made via view sets
+            # in UI views, but will include HTMX-initiated async API
+            # requests made in response to user actions (including search).
+            # Thus they can be set quite low for anonymous
+            # users without affecting anon user page views.
+            # A `429 Too Many Requests` response is returned when rate
+            # limits are exceeded.
+            "anon": "100/hour",
+            "user": "5000/hour",
+        },
         "EXCEPTION_HANDLER": "manager.api.handlers.custom_exception_handler",
         "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
         "PAGE_SIZE": 50,

--- a/manager/manager/templates/base.html
+++ b/manager/manager/templates/base.html
@@ -230,9 +230,9 @@
     {% for message in messages %}
     <script>
       manager.Toast({
-        message: "{% if 'safe' in message.tags %}{{ message|safe }}{% else %}{{ message }}{% endif %}",
+        message: `{% if 'safe' in message.tags %}{{ message|safe }}{% else %}{{ message }}{% endif %}`,
         type: "{% if message.level_tag == "error" %}is-danger{% else %}is-{{ message.level_tag }}{% endif %}",
-        duration: 5000,
+        duration: {% if 'stay' in message.tags %}1e8{% else %}5000{% endif %},
         position: "bottom-left",
         closeOnClick: true,
         pauseOnHover: true,

--- a/manager/manager/templates/base.html
+++ b/manager/manager/templates/base.html
@@ -1,4 +1,4 @@
-{% load static intercom %}
+{% load static intercom waffle_tags %}
 {% load i18n %}
 
 <!DOCTYPE html>
@@ -79,6 +79,16 @@
         </div>
         <div id="navbar-menu" class="navbar-menu">
           <div class="navbar-start">
+            {% flag 'ui-projects-open' %}
+            <div class="navbar-item px-0">
+              <a class="navbar-link is-arrowless" href="{% url 'ui-projects-open' %}">
+                <span class="icon">
+                  <i class="ri-book-open-line" aria-hidden="true"></i>
+                </span>
+                <span>{% trans "Open" %}</span>
+              </a>
+            </div>
+            {% endflag %}
             <div class="navbar-item px-0 {% if user.is_authenticated %}has-dropdown{% endif%}">
               <a class="navbar-link {% if user.is_anonymous %}is-arrowless{% endif%}"
                  href="{% url 'ui-projects-list' %}">

--- a/manager/projects/admin.py
+++ b/manager/projects/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from projects.models.projects import Project
+from projects.models.projects import Project, ProjectAgent
 from projects.models.snapshots import Snapshot
 
 
@@ -17,6 +17,14 @@ class ProjectAdmin(admin.ModelAdmin):
         "public",
     ]
     list_select_related = ["account", "creator"]
+
+
+@admin.register(ProjectAgent)
+class ProjectAgentAdmin(admin.ModelAdmin):
+    """Admin interface for projects agents."""
+
+    list_display = ["id", "project", "user_id", "team_id", "role"]
+    list_select_related = ["project"]
 
 
 @admin.register(Snapshot)

--- a/manager/projects/admin.py
+++ b/manager/projects/admin.py
@@ -10,10 +10,13 @@ class ProjectAdmin(admin.ModelAdmin):
 
     list_display = [
         "name",
+        "account",
         "creator",
         "created",
+        "temporary",
+        "public",
     ]
-    list_select_related = ["creator"]
+    list_select_related = ["account", "creator"]
 
 
 @admin.register(Snapshot)

--- a/manager/projects/api/serializers.py
+++ b/manager/projects/api/serializers.py
@@ -373,9 +373,9 @@ class ProjectUpdateSerializer(ProjectSerializer):
         project = self.instance
 
         # If the project is being made non-temporary we need
-        # to ensure that the current user is made the owner
+        # to ensure that the current user is made a owner (if they are not already)
         if project.temporary and data.get("temporary") is False:
-            ProjectAgent.objects.create(
+            ProjectAgent.objects.get_or_create(
                 project=project, user=request.user, role=ProjectRole.OWNER.name
             )
 

--- a/manager/projects/migrations/0004_add_project_temporary.py
+++ b/manager/projects/migrations/0004_add_project_temporary.py
@@ -1,0 +1,37 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+def temp_account(apps, *args):
+    """
+    Create a temp account that will own temporary projects.
+    """
+    Account = apps.get_model("accounts", "Account")
+    Account.objects.create(name="temp", display_name="Temporary projects")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('projects', '0003_auto_20200712_2322'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='project',
+            name='temporary',
+            field=models.BooleanField(default=False, help_text='Is the project temporary?'),
+        ),
+        migrations.RunPython(temp_account),
+        migrations.AlterField(
+            model_name='project',
+            name='creator',
+            field=models.ForeignKey(blank=True, help_text='The user who created the project.', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='projects_created', to=settings.AUTH_USER_MODEL),
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='public',
+            field=models.BooleanField(default=True, help_text='Is the project publicly visible?'),
+        ),
+    ]

--- a/manager/projects/models/projects.py
+++ b/manager/projects/models/projects.py
@@ -1,3 +1,6 @@
+import datetime
+from typing import Optional
+
 from django.db import models
 from django.db.models.signals import post_save
 
@@ -24,8 +27,9 @@ class Project(models.Model):
     )
 
     creator = models.ForeignKey(
-        "auth.User",
+        User,
         null=True,
+        blank=True,
         on_delete=models.SET_NULL,
         related_name="projects_created",
         help_text="The user who created the project.",
@@ -49,8 +53,12 @@ class Project(models.Model):
         help_text="Title of the project to display in its profile.",
     )
 
+    temporary = models.BooleanField(
+        default=False, help_text="Is the project temporary?"
+    )
+
     public = models.BooleanField(
-        default=True, help_text="Should the project be publicly visible?"
+        default=True, help_text="Is the project publicly visible?"
     )
 
     description = models.TextField(
@@ -79,6 +87,19 @@ class Project(models.Model):
                 fields=["account", "name"], name="%(class)s_unique_account_name"
             )
         ]
+
+    TEMPORARY_PROJECT_LIFESPAN = datetime.timedelta(days=1)
+
+    @property
+    def scheduled_deletion_time(self) -> Optional[datetime.datetime]:
+        """
+        Get the scheduled deletion time of a temporary project.
+        """
+        return (
+            (self.created + Project.TEMPORARY_PROJECT_LIFESPAN)
+            if self.temporary
+            else None
+        )
 
     def get_main(self):
         """

--- a/manager/projects/models/projects.py
+++ b/manager/projects/models/projects.py
@@ -90,6 +90,9 @@ class Project(models.Model):
 
     TEMPORARY_PROJECT_LIFESPAN = datetime.timedelta(days=1)
 
+    def __str__(self):
+        return self.name
+
     @property
     def scheduled_deletion_time(self) -> Optional[datetime.datetime]:
         """

--- a/manager/projects/models/sources.py
+++ b/manager/projects/models/sources.py
@@ -1,7 +1,7 @@
 import datetime
 import os
 import re
-from typing import List, Optional, Type, Union
+from typing import Any, Dict, List, Optional, Type, Union
 
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
@@ -252,15 +252,18 @@ class Source(PolymorphicModel):
         return models.Q(**kwargs)
 
     @staticmethod
-    def from_address(address_or_string: Union[SourceAddress, str]) -> "Source":
+    def from_address(
+        address_or_string: Union[SourceAddress, str], other: Dict[str, Any] = {}
+    ) -> "Source":
         """
         Create a source instance from a source address.
 
         Given a source address, creates a new source instance of the
-        specified `type` with fields set from the address.
+        specified `type` with fields set from the address. The `other`
+        parameter can be used to set additional fields on the created source.
         """
         address = Source.coerce_address(address_or_string)
-        return address.type.objects.create(**address)
+        return address.type.objects.create(**address, **other)
 
     def to_address(self) -> SourceAddress:
         """
@@ -720,7 +723,3 @@ class UrlSource(Source):
             raise ValidationError("Invalid URL source: {}".format(address))
 
         return None
-
-    def to_address(self):
-        """Override base method which (intentionally) excludes `url`."""
-        return dict(**super().to_address(), url=self.url)

--- a/manager/projects/paths.py
+++ b/manager/projects/paths.py
@@ -11,6 +11,7 @@ class ProjectPaths(enum.Enum):
     disallowed file paths within a project, up to date.
     """
 
+    claim = "claim"
     files = "files"
     jobs = "jobs"
     sharing = "sharing"

--- a/manager/projects/templates/projects/_claim_form.html
+++ b/manager/projects/templates/projects/_claim_form.html
@@ -1,0 +1,18 @@
+{% load i18n %}
+
+<form hx-patch="{% url "api-projects-detail" project.name %}"
+      include-vals="public: document.querySelector('form [name=public]').checked, temporary: false"
+      hx-template="projects/_claim_form.html" hx-redirect="UPDATED:Location">
+
+  {% include "serializers/_field.html" with field=serializer.account icon="ri-at-line" %}
+  {% include "serializers/_field.html" with field=serializer.name icon="ri-at-line" autofocus=True %}
+  {% include "serializers/_field.html" with field=serializer.public icon="ri-globe-line" element="checkbox" %}
+
+  <button class="button is-primary is-fullwidth-mobile" type="submit">
+    <span class="icon">
+      <i class="ri-handbag-fill"></i>
+    </span>
+    <span>{% trans "Claim Project" %}</span>
+  </button>
+
+</form>

--- a/manager/projects/templates/projects/base.html
+++ b/manager/projects/templates/projects/base.html
@@ -8,6 +8,19 @@
     {{ project.title|default:project.name }}
   </h1>
 
+  {% if project.temporary %}
+  <a href="{% url 'ui-projects-claim' project.account.name project.name %}">
+    <span class="tag is-warning is-light">
+      <span class="icon">
+        <i class="ri-recycle-line"></i>
+      </span>
+      <span>
+        {% trans "Temporary" %}
+      </span>
+    </span>
+  </a>
+  {% endif %}
+
   <hr />
 </div>
 
@@ -37,6 +50,19 @@
       </a>
     </li>
 
+    {% if project.temporary %}
+    <li class="sidebar__item" id="menu-item-snapshots">
+      <a href="{% url 'ui-projects-claim' project.account.name project.name %}"
+         class="panel-block transition-colors {% is_active 'ui-projects-claim' %} has-tooltip-bottom has-tooltip-text-centered image-tooltip">
+        <span class="icon">
+          <i class="ri-handbag-line"></i>
+        </span>
+        <span>
+          {% trans 'Claim' %}
+        </span>
+      </a>
+    </li>
+    {% else %}
     <li class="sidebar__item" id="menu-item-snapshots">
       <a href="{% url 'ui-projects-snapshots-list' project.account.name project.name %}"
          class="panel-block transition-colors {% is_active 'ui-projects-snapshots' %} has-tooltip-bottom has-tooltip-text-centered image-tooltip">
@@ -87,6 +113,7 @@
         </span>
       </a>
     </li>
+    {% endif %}
     {% endif %}
   </ul>
 </div>

--- a/manager/projects/templates/projects/claim.html
+++ b/manager/projects/templates/projects/claim.html
@@ -1,0 +1,22 @@
+{% extends './base.html' %}
+{% load i18n %}
+
+{% block title %}{% trans "Claim project" %} {{ project.name }}{% endblock %}
+
+{% block projects_content %}
+<h1 class="title is-sr-only-mobile">{% trans "Claim project" %}</h1>
+
+{% if user.is_anonymous %}
+{% url 'ui-users-signin' as signin_url %}
+{% url 'ui-users-signup' as signup_url %}
+{% blocktrans with current_url=request.path %}
+<p>Please <a href="{{ signin_url }}?next={{ current_url }}">sign in</a> with an existing account,
+  or <a href="{{ signup_url }}?next={{ current_url }}">sign up</a> for a new account, to claim this project.</p>
+{% endblocktrans %}
+{% else %}
+<p>Please choose a new name and account for the project</p>
+{% include "./_claim_form.html" %}
+{% endif %}
+
+
+{% endblock %}

--- a/manager/projects/templates/projects/messages/temporary_project.html
+++ b/manager/projects/templates/projects/messages/temporary_project.html
@@ -1,0 +1,6 @@
+{% spaceless %}
+{% load i18n humanize %}
+{% url 'ui-projects-claim' project.account.name project.name as claim_url %}
+{% blocktrans with in_time=deletion_time|naturaltime %}This project will be deleted {{ in_time }}. Or you can <a
+   href="{{ claim_url }}">claim it</a>.{% endblocktrans %}
+{% endspaceless %}

--- a/manager/projects/templates/projects/open.html
+++ b/manager/projects/templates/projects/open.html
@@ -1,0 +1,7 @@
+{% extends 'base_centered.html' %}
+{% load i18n %}
+
+{% block title %}{% trans "Open" %}{% endblock %}
+
+{% block layout_content %}
+{% endblock %}

--- a/manager/projects/templates/projects/open.html
+++ b/manager/projects/templates/projects/open.html
@@ -1,7 +1,62 @@
 {% extends 'base_centered.html' %}
 {% load i18n %}
 
+{% comment %}
+This is very much a work in progress.
+See comments at https://github.com/stencila/hub/pull/552
+{% endcomment %}
+
 {% block title %}{% trans "Open" %}{% endblock %}
 
 {% block layout_content %}
+
+<form method="POST">
+  {% csrf_token %}
+
+  <label class="label" for="url">URL</label>
+  <div class="control has-icons-left">
+    <input class="input" name="url" id="url" type="url" autofocus="" value="">
+    <span class="icon is-left">
+      <i class="ri-links-line"></i>
+    </span>
+  </div>
+  <div class="control">
+    <button class="button is-primary is-fullwidth-mobile" type="submit">
+      Submit
+    </button>
+  </div>
+</form>
+
+<hr />
+
+<form method="POST" enctype="multipart/form-data">
+  {% csrf_token %}
+
+  <div class="field has-addons-tablet">
+    <div class="control">
+      <div class="file has-name" data-bulma-attached="attached">
+        <label class="file-label">
+          <input class="file-input" type="file" name="file">
+          <span class="file-cta">
+            <span class="file-icon">
+              <i class="ri-file-upload-line"></i>
+            </span>
+            <span class="file-label">
+              Choose a file…
+            </span>
+          </span>
+          <span class="file-name">
+            No file chosen
+          </span>
+        </label>
+      </div>
+    </div>
+    <div class="control">
+      <button class="button is-primary is-fullwidth-mobile" type="submit">
+        Upload
+      </button>
+    </div>
+  </div>
+</form>
+
 {% endblock %}

--- a/manager/projects/templates/projects/update.html
+++ b/manager/projects/templates/projects/update.html
@@ -4,20 +4,20 @@
 {% block title %}{{ project.name }} {% trans "Settings" %}{% endblock %}
 
 {% block projects_content %}
-<h1 class="title is-sr-only-mobile">{% trans "Project Settings" %}</h2>
+<h1 class="title is-sr-only-mobile">{% trans "Project Settings" %}</h1>
 
-  {% include "./_update_profile_form.html" %}
+{% include "./_update_profile_form.html" %}
 
-  <hr>
+<hr>
 
-  <h2 class="title is-3">{% trans "Content" %}</h2>
-  <p class="subtitle is-6">{% trans "Settings affecting how content is served for this project." %}</p>
+<h2 class="title is-3">{% trans "Content" %}</h2>
+<p class="subtitle is-6">{% trans "Settings affecting how content is served for this project." %}</p>
 
-  {% include "./_update_content_form.html" %}
+{% include "./_update_content_form.html" %}
 
-  <hr />
+<hr />
 
-  <h2 class="title is-4 is-outlined">{% trans "Delete" %}</h2>
-  {% include "./_destroy_form.html" with serializer=destroy_serializer %}
+<h2 class="title is-4 is-outlined">{% trans "Delete" %}</h2>
+{% include "./_destroy_form.html" with serializer=destroy_serializer %}
 
-  {% endblock %}
+{% endblock %}

--- a/manager/projects/ui/urls.py
+++ b/manager/projects/ui/urls.py
@@ -16,8 +16,9 @@ before_account_urls = [
         project_views.create,
         name="ui-projects-create",
     ),
+    path("open/", project_views.open, name="ui-projects-open",),
     re_path(
-        r"^(?P<account>[^/]+)/(?P<project>\d+)(?P<rest>.*)",
+        r"^(?P<account>[^/]+)/(?P<project>\d+)/(?P<rest>.*)",
         project_views.redirect,
         name="ui-projects-redirect",
     ),
@@ -30,6 +31,11 @@ after_account_urls = [
         include(
             [
                 path("", project_views.retrieve, name="ui-projects-retrieve",),
+                path(
+                    ProjectPaths.claim.value + "/",
+                    project_views.claim,
+                    name="ui-projects-claim",
+                ),
                 path(
                     ProjectPaths.sharing.value + "/",
                     project_views.sharing,

--- a/manager/projects/ui/views/files.py
+++ b/manager/projects/ui/views/files.py
@@ -2,6 +2,7 @@ from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 
 from projects.api.views.files import ProjectsFilesViewSet
+from projects.ui.views.messages import all_messages
 
 
 def list(request: HttpRequest, *args, **kwargs) -> HttpResponse:
@@ -24,6 +25,8 @@ def list(request: HttpRequest, *args, **kwargs) -> HttpResponse:
     project = viewset.get_project()
     files = viewset.get_queryset(project)
     context = viewset.get_response_context(queryset=files)
+
+    all_messages(request, project)
 
     return render(
         request, "projects/files/list.html", dict(project=project, **context),

--- a/manager/projects/ui/views/messages.py
+++ b/manager/projects/ui/views/messages.py
@@ -1,0 +1,42 @@
+"""
+A module for generating project related messages to users.
+
+This is intended to be used across most project related views to
+notify the user of potential limits (e.g. approaching maximum job limits)
+"""
+import datetime
+from typing import List
+
+from django.contrib import messages
+from django.http import HttpRequest
+from django.template.loader import render_to_string
+
+from manager.helpers import should_send_message
+from projects.models.projects import Project
+
+
+def all_messages(request: HttpRequest, project: Project, exclude: List[str] = []):
+    """
+    Generate all messages for a project (except those listed in `exclude`).
+    """
+    if "temporary_project" not in exclude:
+        temporary_project(request, project)
+
+
+def temporary_project(request: HttpRequest, project: Project):
+    """
+    Warn the user that this is a temporary project and that they can claim it.
+    """
+    if project.temporary and should_send_message(
+        request,
+        "temporary_project_{}".format(project.name),
+        datetime.timedelta(minutes=1),
+    ):
+        messages.warning(
+            request,
+            render_to_string(
+                "projects/messages/temporary_project.html",
+                dict(project=project, deletion_time=project.scheduled_deletion_time),
+            ),
+            extra_tags="stay safe",
+        )

--- a/manager/projects/ui/views/projects.py
+++ b/manager/projects/ui/views/projects.py
@@ -1,10 +1,11 @@
 from django.contrib.auth.decorators import login_required
-from django.http import HttpRequest, HttpResponse
+from django.http import Http404, HttpRequest, HttpResponse
 from django.shortcuts import redirect as redir
 from django.shortcuts import render
 
 from projects.api.serializers import ProjectDestroySerializer
 from projects.api.views.projects import ProjectsViewSet
+from projects.models.sources import Source, UploadSource
 
 
 def redirect(request: HttpRequest, *args, **kwargs) -> HttpResponse:
@@ -40,7 +41,7 @@ def create(request: HttpRequest, *args, **kwargs) -> HttpResponse:
     and set the name and public/private flag of the project.
     """
     viewset = ProjectsViewSet.init("create", request, args, kwargs)
-    serializer = viewset.get_serializer()
+    serializer = viewset.get_serializer(dict(public=True))
     return render(request, "projects/create.html", dict(serializer=serializer))
 
 
@@ -53,13 +54,35 @@ def open(request: HttpRequest, *args, **kwargs) -> HttpResponse:
     if they wish. It aims to be a quick way to start a project and preview
     publishing of a file.
 
-    If a GET request and the URL has a `source` query parameter, then that will
-    be parsed as the project source.
-
-    If a POST request and `files`, then create an `upload` source, otherwise
-    validate the form and submit.
+    TODO: See https://github.com/stencila/hub/pull/552 for more todos
     """
-    return render(request, "projects/open.html")
+    if request.method == "GET":
+        # TODO: If a GET request attempt to get source from end of URL or a query parameter
+        return render(request, "projects/open.html")
+
+    if request.method == "POST":
+        viewset = ProjectsViewSet.init("create", request, args, kwargs)
+        serializer = viewset.get_serializer(data=dict(temporary=True, public=True))
+        serializer.is_valid(raise_exception=True)
+        project = serializer.create(serializer.validated_data)
+
+        url = request.POST.get("url")
+        if url:
+            Source.from_address(url, dict(project=project, path="main"))
+
+        file = request.FILES.get("file")
+        if file:
+            UploadSource.objects.create(project=project, path=file.name, file=file)
+
+        # TODO: Make the source the project's main file. How to do before pulling it?
+
+        # TODO: Create a newer simpler job preview page, that is visible to
+        # anon users and redirect to that instead of to the project overview page
+        # job = source.pull()
+
+        return redir("ui-projects-retrieve", "temp", project.name)
+
+    raise Http404
 
 
 def claim(request: HttpRequest, *args, **kwargs) -> HttpResponse:

--- a/manager/projects/ui/views/sources.py
+++ b/manager/projects/ui/views/sources.py
@@ -7,6 +7,7 @@ from projects.api.views.sources import ProjectsSourcesViewSet
 from projects.models.sources import Source, UploadSource
 from projects.ui.views.messages import all_messages
 
+
 def list(request: HttpRequest, *args, **kwargs) -> HttpResponse:
     """Get a list of project sources."""
     viewset = ProjectsSourcesViewSet.init("list", request, args, kwargs)

--- a/manager/projects/ui/views/sources.py
+++ b/manager/projects/ui/views/sources.py
@@ -5,13 +5,16 @@ from django.template.loader import select_template
 
 from projects.api.views.sources import ProjectsSourcesViewSet
 from projects.models.sources import Source, UploadSource
-
+from projects.ui.views.messages import all_messages
 
 def list(request: HttpRequest, *args, **kwargs) -> HttpResponse:
     """Get a list of project sources."""
     viewset = ProjectsSourcesViewSet.init("list", request, args, kwargs)
     project = viewset.get_project()
     sources = viewset.get_queryset(project)
+
+    all_messages(request, project)
+
     return render(
         request, "projects/sources.html", dict(sources=sources, project=project)
     )

--- a/manager/scripts/create_dev_db.py
+++ b/manager/scripts/create_dev_db.py
@@ -180,7 +180,7 @@ def run(*args):
     # the generic `member`, `manager` etc accounts all have access to
     # at the corresponding levels
 
-    for account in Account.objects.all():
+    for account in Account.objects.all().exclude(name__in=("stencila", "temp")):
         public = Project.objects.create(
             name="first-project",
             title="First project",


### PR DESCRIPTION
Before deprecating the `director` completely I wanted to check out how easily we could  reimplement `/open` in `manager`, including the notion that a `/open` "conversion" is just one way to kick start a project, including for anonymous users, by providing a "wizard" to make a particular source the "main" project file. 

Towards that, this PR:

- [x] adds the concept of a `temporary` project that is scheduled for deletion
- [x] temporary projects have a very-difficult-to-guess "secret" name under the `temp` account e.g. `temp/WawTTwoEbiAzUf23k2RJDz`
- [x] a message warns the user that the project is temporary
- [x] anyone, even anonymous users, can access that project and "claim it" ie. make it non-temporary, associate it with an account and rename it.

#### User visits `/open`

This is a very initial, bare bones page, needs to go towards existing `/open` page

![image](https://user-images.githubusercontent.com/1152336/87295576-89a0cf00-c559-11ea-951c-c781d42be8a6.png)

- [ ] improve layout and text
- [ ] add examples

#### User get's redirected to the pull job

I envisage the user gets redirect to a very simple "in progress" page - a simple message and a progress bar, with a redirect to the next page below when the job is complete.

![image](https://user-images.githubusercontent.com/1152336/87295838-ed2afc80-c559-11ea-87e8-3184054888e1.png)

- [ ] create a new job progress page (could be used for any type of job)

#### User sees preview page

I think we should keep the steps 2 and 3 (preview and "final") page of the existing `/open` but they will be something like "project theme selector" and "project overview" pages rather than `/open` specific. In any case, for those and other project views the user gets a message informing them that this is a temporary project. This is just an indication of what that looks like now:

![image](https://user-images.githubusercontent.com/1152336/87295969-26fc0300-c55a-11ea-8ef0-f0bd7ff11c2b.png)

- [ ] create a project overview page which shows the main file, with the selected theme (like we currently do for snapshots), with dropdowns to download the project in various formats

#### User claims a project

If the user in unauthenticated they are asked to sign in or up first. Note that the links on this page will redirect the user back to the claim page afterwards so are probably best made more prominent / buttons:

![image](https://user-images.githubusercontent.com/1152336/87296519-fff20100-c55a-11ea-8b15-20d3ebf3cfa1.png)

Once / if the user is signed in the project claim page has a form which allows them to associate it with an account, give it a name, and decide if to make it private (subject to limits on their account):

![image](https://user-images.githubusercontent.com/1152336/87296165-75a99d00-c55a-11ea-88df-313ebb9fc4de.png)

Other to do:

- [ ] the file that is "opened" should become the main file of the project
- [ ] add cron job to do deletion of temporary projects
- [ ] add a redirect table for projects, with a row added each time a project is renamed (this will allow users to claim and rename a project while still ensuring those with the original link have access)

@alex-ketch I'd be grateful if you could review the flows here e.g. going from trying out opening a file, to sharing it a friend, to you or them claiming the project and renaming it etc. In addition to the above there are also some code comments around authorisation for temp projects. If you want to jump in and do any tidyups on the templates / CSS, that'd be greaat too! :)

