### PR TITLE
Fix JS usage after splitting into multiple files

### DIFF
--- a/manager/Makefile
+++ b/manager/Makefile
@@ -27,6 +27,7 @@ setup: venv
 # and node_modules
 venv: requirements.txt  requirements-dev.txt package.json
 	$(PYTHON) -m venv venv
+	$(VE)/pip3 install wheel
 	$(VE)/pip3 install -r requirements.txt
 	$(VE)/pip3 install -r requirements-dev.txt
 	touch venv

--- a/manager/manager/static/js/src/libs.js
+++ b/manager/manager/static/js/src/libs.js
@@ -1,5 +1,5 @@
 // Third-party JS which is unlikely to change frequently and can be cached for longer periods of time
-// These are available as `manager.Toast` etc
+// These are available as `managerLibs.Toast` etc
 export { File } from "@vizuaalog/bulmajs/src/plugins/file";
 export { Navbar } from "@vizuaalog/bulmajs/src/plugins/navbar";
 export { toast as Toast } from "bulma-toast";

--- a/manager/manager/templates/base.html
+++ b/manager/manager/templates/base.html
@@ -245,7 +245,7 @@
   <div id="messages">
     {% for message in messages %}
     <script>
-      manager.Toast({
+      managerLibs.Toast({
         message: `{% if 'safe' in message.tags %}{{ message|safe }}{% else %}{{ message }}{% endif %}`,
         type: "{% if message.level_tag == "error" %}is-danger{% else %}is-{{ message.level_tag }}{% endif %}",
         duration: {% if 'stay' in message.tags %}1e8{% else %}5000{% endif %},

--- a/manager/users/templates/users/signout.html
+++ b/manager/users/templates/users/signout.html
@@ -30,7 +30,8 @@
       <form class="form" method="post" action="{% url 'ui-users-signout' %}">
         {% csrf_token %}
         <div class="buttons">
-          <button class="button is-primary is-fullwidth-mobile" type="submit" onclick="posthog.reset()">
+          <button class="button is-primary is-fullwidth-mobile" type="submit"
+                  {% if POSTHOG_KEY %}onclick="posthog.reset()" {% endif %}>
             <span class="icon">
               <i class="ri-logout-box-line"></i>
             </span>


### PR DESCRIPTION
After splitting JS files into two, the 3rd party libraries are exposed using a `managerLibs` object instead of simply `manager`.