### PR TITLE
User search

### DIFF
--- a/manager/manager/static/sass/projects/index.scss
+++ b/manager/manager/static/sass/projects/index.scss
@@ -1,6 +1,6 @@
 @import "./sources/index.scss";
 
-@media screen and (min-width: $tablet){
+@media screen and (min-width: $tablet) {
   .project-description {
     padding-right: $gap;
   }
@@ -58,7 +58,7 @@
   padding: 2rem 0;
   position: relative;
 
-  @media screen and (max-width: $tablet){
+  @media screen and (max-width: $tablet) {
     .column {
       padding-bottom: $gap / 4;
       padding-top: $gap / 4;
@@ -97,7 +97,7 @@
     border: 2px solid $grey-lighter;
     color: $text;
     content: "\EF90";
-    font-family: remixicon!important;
+    font-family: remixicon !important;
     font-size: 14px;
     height: 28px;
     left: -14px;
@@ -135,7 +135,7 @@
       border: 2px solid $grey-lighter;
       color: $text;
       content: "";
-      font-family: remixicon!important;
+      font-family: remixicon !important;
       font-size: 14px;
       height: 8px;
       left: -1px;
@@ -169,7 +169,7 @@ a.job-list--id {
     }
 
     &:not(:last-child):after {
-      content: '·';
+      content: "·";
       display: inline-block;
       padding: 0 0.25rem;
       vertical-align: middle;
@@ -184,7 +184,7 @@ a.job-list--id {
 .snapshot--preview {
   border-radius: 4px;
   border: 1px solid $grey-lightest;
-  box-shadow: 0 0 8px rgba(0,0,0,.035),0 0 40px rgba(0,0,0,.07);
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.035), 0 0 40px rgba(0, 0, 0, 0.07);
   height: calc(100vh - 6rem);
   width: 100%;
 }

--- a/manager/manager/static/sass/projects/sources/index.scss
+++ b/manager/manager/static/sass/projects/sources/index.scss
@@ -1,7 +1,3 @@
 .source-table--file-type {
   width: 1em;
 }
-
-// a.table-icon-label {
-//   @extend .expand-link;
-// }

--- a/manager/manager/static/sass/styles.scss
+++ b/manager/manager/static/sass/styles.scss
@@ -842,6 +842,21 @@ a .icon + span,
   }
 }
 
+.user-search-item {
+  cursor: pointer;
+  line-height: 1;
+
+  &:hover {
+    background-color: $white-ter;
+  }
+}
+
+.user-search-item--email {
+  &:before {
+    content: " · ";
+  }
+}
+
 #messages {
   // Places messages in the top left
   position: sticky;

--- a/manager/manager/static/sass/styles.scss
+++ b/manager/manager/static/sass/styles.scss
@@ -460,7 +460,6 @@ body {
   }
 }
 
-
 .field.has-addons-tablet .control {
   &:not(:last-of-type) {
     .file.has-name .file-name {
@@ -506,7 +505,7 @@ body {
 }
 
 .leading-loose {
-  line-height: 2
+  line-height: 2;
 }
 
 .width-full {

--- a/manager/users/api/views/users.py
+++ b/manager/users/api/views/users.py
@@ -32,7 +32,7 @@ class UsersViewSet(
     def get_queryset(self) -> QuerySet:
         """
         Get all users, or only those matching the search query (if provided).
-        
+
         Often, fields from the user's personal account (e.g. image) will be wanted
         so that is `select_related`ed.
         """

--- a/manager/users/api/views/users.py
+++ b/manager/users/api/views/users.py
@@ -30,17 +30,33 @@ class UsersViewSet(
     permission_classes = ()
 
     def get_queryset(self) -> QuerySet:
-        """Get all users, or only those matching the search query (if provided)."""
-        search = self.request.GET.get("search")
-        if search is None:
-            return User.objects.all()
+        """
+        Get all users, or only those matching the search query (if provided).
+        
+        Often, fields from the user's personal account (e.g. image) will be wanted
+        so that is `select_related`ed.
+        """
+        queryset = User.objects.all().select_related("personal_account")
 
-        return User.objects.filter(
-            Q(username__icontains=search)
-            | Q(first_name__icontains=search)
-            | Q(last_name__icontains=search)
-            | Q(email__icontains=search)
-        )
+        search = self.request.GET.get("search")
+        if search:
+            queryset = queryset.filter(
+                Q(username__icontains=search)
+                | Q(first_name__icontains=search)
+                | Q(last_name__icontains=search)
+                | Q(email__icontains=search)
+            )
+
+        limit = self.request.GET.get("limit")
+        if limit:
+            try:
+                limit = int(limit)
+            except ValueError:
+                pass
+            else:
+                queryset = queryset[:limit]
+
+        return queryset
 
     def get_serializer_class(self):
         """

--- a/manager/users/templates/users/_search.html
+++ b/manager/users/templates/users/_search.html
@@ -10,7 +10,7 @@ e.g. adding another user to a team, or a project.
 Inspired by Github's user search field (amongst others).
 {% endcomment %}
 <label for="user-search-input" class="label is-sr-only">{% trans "Search users" %}</label>
-<div id="user-search" class="dropdown is-expanded">
+<div id="user-search" class="dropdown is-expanded is-active">
   <div class="dropdown-trigger">
     <div class="control has-icons-left has-icons-right">
       <input id="user-search-input" class="input" type="text" name="search"
@@ -31,6 +31,7 @@ Inspired by Github's user search field (amongst others).
     <input id="user-search-result-id" type="hidden" name="{{ id_name|default:'id' }}">
   </div>
   <div class="dropdown-menu"></div>
+
   <script>
     var $search = document.querySelector('#user-search')
     // Add query parameters to search

--- a/manager/users/templates/users/_search_results.html
+++ b/manager/users/templates/users/_search_results.html
@@ -7,11 +7,15 @@ for displaying user search results.
 <div class="dropdown-content">
   {% for user in queryset %}
   <div class="dropdown-item" data-id="{{ user.id }}" data-username="{{ user.username }}">
+    {% with account=user.personal_account %}
     <figure class="image is-24x24" style="width:24px">
-      <img src="{{ user.personal_account.image.small }}" alt="{{ user.get_full_name|default:user.username }}"></img>
+      <img src="{{ account.image.small }}" alt="{{ user.get_full_name|default:user.username }}"></img>
     </figure>
     <strong>{{ user.username }}</strong>&nbsp;&nbsp;
-    <span>{{ user.first_name }} {{ user.last_name }}<span>
+    <span>{{ user.first_name }} {{ user.last_name }}</span>
+    {% if account.email %}<span>{{ account.email }}</span>{% endif %}
+    {% if account.location %}<span>{{ account.location }}</span>{% endif %}
+    {% endwith %}
   </div>
   {% empty %}
   <div class="dropdown-item">

--- a/manager/users/templates/users/_search_results.html
+++ b/manager/users/templates/users/_search_results.html
@@ -1,25 +1,31 @@
+{% load i18n %}
+
 {% comment %}
 Display user search results.
 
 Intended to be used with `users/_search.html`
 for displaying user search results.
 {% endcomment %}
-<div class="dropdown-content">
+
+<ul class="dropdown-content">
   {% for user in queryset %}
-  <div class="dropdown-item" data-id="{{ user.id }}" data-username="{{ user.username }}">
+  <li class="dropdown-item user-search-item py-2" data-id="{{ user.id }}" data-username="{{ user.username }}">
     {% with account=user.personal_account %}
-    <figure class="image is-24x24" style="width:24px">
+    <figure class="image is-32x32 is-inline-block mr-2 is-vcentered">
       <img src="{{ account.image.small }}" alt="{{ user.get_full_name|default:user.username }}"></img>
     </figure>
-    <strong>{{ user.username }}</strong>&nbsp;&nbsp;
-    <span>{{ user.first_name }} {{ user.last_name }}</span>
-    {% if account.email %}<span>{{ account.email }}</span>{% endif %}
-    {% if account.location %}<span>{{ account.location }}</span>{% endif %}
+    <div class="is-inline-block is-vcentered">
+      <div class="has-text-weight-bold is-size-6">{{ user.first_name }} {{ user.last_name }}</div>
+      <span class="is-size-6">
+        {{ user.username }}
+        {% if account.email %}<span class="user-search-item--email">{{ account.email }}</span>{% endif %}
+      </span>
+    </div>
     {% endwith %}
-  </div>
+  </li>
   {% empty %}
-  <div class="dropdown-item">
-    Sorry, could not find a matching user.
-  </div>
+  <li class="dropdown-item has-text-weight-bold">
+    {% trans "Sorry, could not find a matching user." %}
+  </li>
   {% endfor %}
-</div>
+</ul>

--- a/manager/users/templates/users/_search_results.html
+++ b/manager/users/templates/users/_search_results.html
@@ -7,6 +7,9 @@ for displaying user search results.
 <div class="dropdown-content">
   {% for user in queryset %}
   <div class="dropdown-item" data-id="{{ user.id }}" data-username="{{ user.username }}">
+    <figure class="image is-24x24" style="width:24px">
+      <img src="{{ user.personal_account.image.small }}" alt="{{ user.get_full_name|default:user.username }}"></img>
+    </figure>
     <strong>{{ user.username }}</strong>&nbsp;&nbsp;
     <span>{{ user.first_name }} {{ user.last_name }}<span>
   </div>


### PR DESCRIPTION
This adds user image and other public identifying information to the user search results to make it easier to identify the correct user when adding them to the project.

@alex-ketch Could you finish off the styling of the results. They currently look like this.

![image](https://user-images.githubusercontent.com/1152336/88118364-7fde3200-cc11-11ea-9aaf-080815de0ccf.png)

I envisaged to lines of text to the right of the image: top line has username and other name, bottom line has any other information that might be useful to display e.g. email, location, affiliation etc

Also probably a good time to look at improving the UX of selecting the user - highlight on hover etc.
