### PR TITLE
fix(User profiles): Allow setting of first and last names

### DIFF
--- a/manager/accounts/api/views.py
+++ b/manager/accounts/api/views.py
@@ -134,6 +134,9 @@ class AccountsViewSet(
         For `partial_update` checks that the useris an account MANAGER or OWNER.
         Only OWNER is permitted to `update_plan` or `destroy`.
         """
+        if hasattr(self, "account"):
+            return self.account
+
         ident = self.kwargs["account"]
         queryset = self.get_queryset().filter(**filter_from_ident(ident))
 
@@ -160,20 +163,20 @@ class AccountsViewSet(
 
         try:
             # Using [0] adds LIMIT 1 to query so is more efficient than `.get(**filter)`
-            instance = queryset[0]
+            self.account = account = queryset[0]
         except IndexError:
             raise exceptions.NotFound
 
         if (
             self.action == "partial_update"
-            and instance.role not in [AccountRole.MANAGER.name, AccountRole.OWNER.name]
+            and account.role not in [AccountRole.MANAGER.name, AccountRole.OWNER.name]
         ) or (
             self.action in ("update_plan", "destroy")
-            and instance.role != AccountRole.OWNER.name
+            and account.role != AccountRole.OWNER.name
         ):
             raise exceptions.PermissionDenied
 
-        return instance
+        return account
 
     def get_serializer_class(self):
         """

--- a/manager/accounts/models.py
+++ b/manager/accounts/models.py
@@ -213,7 +213,14 @@ def create_personal_account_for_user(
     Makes sure each user has a personal `Account`.
     """
     if sender is User and created:
-        Account.objects.create(name=instance.username, creator=instance, user=instance)
+        Account.objects.create(
+            name=instance.username,
+            display_name=(
+                (instance.first_name or "") + " " + (instance.last_name or "")
+            ).strip(),
+            creator=instance,
+            user=instance,
+        )
 
 
 post_save.connect(create_personal_account_for_user, sender=User)

--- a/manager/accounts/templates/accounts/_update_profile_fields.html
+++ b/manager/accounts/templates/accounts/_update_profile_fields.html
@@ -3,12 +3,14 @@ Profile related fields of an account.
 
 This is a seperate partial to `accounts/_update_profile_form.html`
 so that these fields can also be used in `accounts/create.html`.
-
-Currently excludes `image` file because file content is not compatible with JSON encoding
-of forms. TODO: Fix, or provide a different form that does not use HTMX.
 {% endcomment %}
 
+{% if account.is_personal %}
+{% include "serializers/_field.html" with field=serializer.first_name icon="ri-honour-line" %}
+{% include "serializers/_field.html" with field=serializer.last_name icon="ri-honour-line" %}
+{% else %}
 {% include "serializers/_field.html" with field=serializer.display_name icon="ri-honour-line" %}
+{% endif %}
 {% include "serializers/_field.html" with field=serializer.location icon="ri-map-pin-line" %}
 {% include "serializers/_field.html" with field=serializer.website icon="ri-links-line" %}
 {% include "serializers/_field.html" with field=serializer.email icon="ri-mail-line" %}


### PR DESCRIPTION
A user's first and last names are stored on Django's built-in user model and were previously only visible via the admin interface e.g.

![image](https://user-images.githubusercontent.com/1152336/88122612-30056800-cc1d-11ea-89e3-32cccd2ec70f.png)

Currently, when a user signs up, they are not able to set first or last names and these fields only get populated via social auth (e.g. we get first and last name if someone signs up via Google).

This PR makes a couple of improvements:

- for personal accounts, a user can change their first and last name using the account profile form (for organisational accounts they can edit the "display name")

- when a user signs up, or when they change their first or last name using the account profile form, the `display_name` of their `personal_account` gets updated

![Peek 2020-07-22 13-21](https://user-images.githubusercontent.com/1152336/88123152-6394c200-cc1e-11ea-994d-3341179a2f18.gif)


@colettedoughty ccing you in here because some changes to documentation may be warranted.