### PR TITLE
Feature and privacy switches

### DIFF
--- a/manager/accounts/templates/accounts/_update_user_settings.html
+++ b/manager/accounts/templates/accounts/_update_user_settings.html
@@ -50,3 +50,16 @@
     </div>
   </div>
 </a>
+<a href="{% url 'ui-users-features' %}" class="list-menu--item">
+  <div class="level is-mobile">
+    <div class="level-left">
+      <span class="icon list-menu--icon"><i class="ri-settings-line"></i></span>
+      <p class="is-uppercase-heading has-text-weight-semibold">Features and privacy</p>
+    </div>
+    <div class="level-right">
+      <div class="control">
+        <span class="icon"><i class="ri-arrow-right-s-line"></i></span>
+      </div>
+    </div>
+  </div>
+</a>

--- a/manager/accounts/templates/accounts/update.html
+++ b/manager/accounts/templates/accounts/update.html
@@ -56,7 +56,7 @@
 
 {% if account.is_personal %}
 <hr>
-<h2 class="title is-3">{% trans "Other" %}</h2>
+<h2 class="title is-3">{% trans "Other settings" %}</h2>
 {% include "accounts/_update_user_settings.html" %}
 {% endif %}
 

--- a/manager/manager/settings.py
+++ b/manager/manager/settings.py
@@ -646,8 +646,10 @@ class Dev(Local):
     STRIPE_TEST_PUBLIC_KEY = values.Value("")
     STRIPE_TEST_SECRET_KEY = values.Value("sk_test_test")
 
-    # In standalone development, default to using a pseudo, in-memory broker
+    # In standalone development, default to using a pseudo, in-memory broker and
+    # phony cache.
     BROKER_URL = values.Value("memory://", environ_prefix=None)
+    CACHE_URL = values.Value("", environ_prefix=None)
 
     # For easier testing allow username/password Basic auth for API
     API_BASIC_AUTH = True

--- a/manager/manager/templates/base.html
+++ b/manager/manager/templates/base.html
@@ -26,6 +26,8 @@
   </script>
   {% endif %}
 
+  {% flag 'crash_monitoring' %}
+  <!-- crash_monitoring: on -->
   {% if SENTRY_DSN %}
   <script src="https://browser.sentry-cdn.com/5.20.1/bundle.min.js"
           integrity="sha384-O8HdAJg1h8RARFowXd2J/r5fIWuinSBtjhwQoPesfVILeXzGpJxvyY/77OaPPXUo" crossorigin="anonymous">
@@ -39,7 +41,10 @@
 
   </script>
   {% endif %}
+  {% endflag %}
 
+  {% flag 'product_analytics' %}
+  <!-- product_analytics: on -->
   {% if POSTHOG_KEY %}
   <script>
     /* beautify ignore:start */
@@ -62,6 +67,7 @@
 
   </script>
   {% endif %}
+  {% endflag %}
 </head>
 
 {% language LANGUAGE_CODE %}
@@ -338,8 +344,13 @@
       <div class="container">
   </footer>
 
+  {% flag 'product_messages' %}
+  <!-- product_messages: on -->
   {% intercom_tag %}
+  {% endflag %}
 
+  {% flag 'product_tours' %}
+  <!-- product_tours: on -->
   {% if USERFLOW_KEY %}
   <script>
     managerLibs.userflow.init('{{ USERFLOW_KEY }}')
@@ -350,6 +361,7 @@
 
   </script>
   {% endif %}
+  {% endflag %}
 
   <div class="modal" id="modal-target">
     <div class="modal-background cursor-close"></div>

--- a/manager/manager/testing.py
+++ b/manager/manager/testing.py
@@ -84,30 +84,31 @@ class DatabaseTestCase(test.APITestCase):
                 )
             )
 
-    def list(self, user: Optional[User], viewname: str, data={}, kwargs={}) -> Response:
+    @staticmethod
+    def reverse(viewname_or_url: str, list_or_detail: str, kwargs={}) -> str:
+        """Get the URL path for a view."""
+        if viewname_or_url.startswith("/"):
+            return viewname_or_url
+        return reverse(
+            viewname_or_url
+            if "-" in viewname_or_url
+            else f"api-{viewname_or_url}-{list_or_detail}",
+            kwargs=kwargs,
+        )
+
+    def list(
+        self, user: Optional[User], viewname: str, data={}, kwargs={}, headers={}
+    ) -> Response:
         """List objects of a type for a user."""
         self.authenticate(user)
-        return self.client.get(
-            reverse(
-                viewname if "-" in viewname else "api-{}-list".format(viewname),
-                kwargs=kwargs,
-            ),
-            data,
-        )
+        return self.client.get(self.reverse(viewname, "list", kwargs), data, **headers)
 
     def create(
         self, user: Optional[User], viewname: str, data={}, kwargs={}, headers={}
     ) -> Response:
         """Create an object of a type for a user."""
         self.authenticate(user)
-        return self.client.post(
-            reverse(
-                viewname if "-" in viewname else "api-{}-list".format(viewname),
-                kwargs=kwargs,
-            ),
-            data,
-            **headers,
-        )
+        return self.client.post(self.reverse(viewname, "list", kwargs), data, **headers)
 
     def retrieve(
         self, user: Optional[User], viewname: str, data={}, kwargs={}, headers={}
@@ -115,10 +116,14 @@ class DatabaseTestCase(test.APITestCase):
         """Create an object of a type for a user."""
         self.authenticate(user)
         return self.client.get(
-            reverse(
-                viewname if "-" in viewname else "api-{}-detail".format(viewname),
-                kwargs=kwargs,
-            ),
-            data,
-            **headers,
+            self.reverse(viewname, "detail", kwargs), data, **headers,
+        )
+
+    def update(
+        self, user: Optional[User], viewname: str, data={}, kwargs={}, headers={}
+    ) -> Response:
+        """Update an object of a type for a user."""
+        self.authenticate(user)
+        return self.client.patch(
+            self.reverse(viewname, "detail", kwargs), data, **headers,
         )

--- a/manager/manager/urls_tests.py
+++ b/manager/manager/urls_tests.py
@@ -73,6 +73,11 @@ checks = [
         ada=title("Manage e-mail addresses")
     ),
     Check(
+        "/me/features/",
+        anon=signin,
+        ada=title("Feature and privacy settings")
+    ),
+    Check(
         "/me/social/connections/",
         anon=signin,
         ada=title("Manage account connections")

--- a/manager/users/admin.py
+++ b/manager/users/admin.py
@@ -83,6 +83,16 @@ class AnonUserAdmin(admin.ModelAdmin):
 
 @admin.register(Flag)
 class FlagAdmin(admin.ModelAdmin):
-    """Admin interface for user feature flags."""
+    """Admin interface for feature and privacy flags."""
 
-    pass
+    list_display = [
+        "name",
+        "settable",
+        "default",
+        "everyone",
+        "percent",
+        "staff",
+        "authenticated",
+        "rollout",
+    ]
+    list_filter = ["settable", "everyone", "staff", "authenticated", "rollout"]

--- a/manager/users/api/urls.py
+++ b/manager/users/api/urls.py
@@ -1,4 +1,7 @@
+from django.urls import re_path
+
 from manager.api.routers import OptionalSlashRouter
+from users.api.views.features import FeaturesView
 from users.api.views.invites import InvitesViewSet
 from users.api.views.tokens import TokensViewSet
 from users.api.views.users import UsersViewSet
@@ -12,4 +15,9 @@ tokens.register("tokens", TokensViewSet, "api-tokens")
 users = OptionalSlashRouter()
 users.register("users", UsersViewSet, "api-users")
 
-urlpatterns = invites.urls + tokens.urls + users.urls
+urlpatterns = (
+    [re_path(r"features/?", FeaturesView.as_view(), name="api-features")]
+    + invites.urls
+    + tokens.urls
+    + users.urls
+)

--- a/manager/users/api/views/features.py
+++ b/manager/users/api/views/features.py
@@ -1,0 +1,90 @@
+from django.db import connection
+from rest_framework import exceptions, generics
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from manager.api.helpers import HtmxMixin
+from users.models import Flag
+
+
+class FeaturesView(
+    HtmxMixin, generics.GenericAPIView,
+):
+    """
+    A view for getting and setting user feature flags.
+
+    This is not a `ViewSet` because it involves a non-standard
+    approach to both getting and setting of feature flags.
+    """
+
+    def get_features(self, request):
+        """
+        Get a dictionary of feature settings for the current user.
+        """
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT "name", "default", "user_id"
+                FROM users_flag
+                LEFT JOIN (
+                    SELECT *
+                    FROM users_flag_users
+                    WHERE user_id = %s
+                ) ON users_flag.id = flag_id
+                WHERE users_flag.settable
+                """,
+                [request.user.id],
+            )
+            rows = cursor.fetchall()
+
+        features = {}
+        for row in rows:
+            name, default, has_flag = row
+            if has_flag:
+                features[name] = "off" if default == "on" else "on"
+            else:
+                features[name] = default
+
+        return features
+
+    def get(self, request: Request) -> Response:
+        """
+        Get the feature settings for the current user.
+        """
+        features = self.get_features(request)
+        return Response(features)
+
+    def patch(self, request: Request) -> Response:
+        """
+        Update the feature settings for the current user.
+        """
+        flags = Flag.objects.filter(settable=True)
+
+        features = request.data
+        for name, value in features.items():
+            try:
+                flag = flags.get(name=name)
+            except Flag.DoesNotExist:
+                raise exceptions.ValidationError(
+                    dict(feature='Invalid feature name "{0}"'.format(name))
+                )
+
+            if value not in (True, False, "on", "off"):
+                raise exceptions.ValidationError(
+                    dict(state='Invalid feature state "{0}"'.format(value))
+                )
+            if value is True:
+                value = "on"
+            elif value is False:
+                value = "off"
+
+            if value != flag.default:
+                flag.users.add(request.user)
+            else:
+                flag.users.remove(request.user)
+
+        if self.accepts_html():
+            return Response(dict(flags=flags))
+        else:
+            features = self.get_features(request)
+            return Response(features)

--- a/manager/users/api/views/features_tests.py
+++ b/manager/users/api/views/features_tests.py
@@ -1,0 +1,41 @@
+from manager.testing import DatabaseTestCase
+from users.models import Flag
+
+
+class FeaturesTestCase(DatabaseTestCase):
+    """Tests getting and setting of feature flags by users."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Add some features to be able to get and set"""
+        super().setUpClass()
+
+        Flag.objects.create(
+            name="feature_a", label="Feature A", default="on", settable=True
+        )
+        Flag.objects.create(
+            name="feature_b", label="Feature B", default="off", settable=True
+        )
+
+    def test_ok(self):
+        features = self.retrieve(self.ada, "api-features").data
+        assert features == {"feature_a": "on", "feature_b": "off"}
+
+        features = self.update(
+            self.ada, "api-features", {"feature_a": "off", "feature_b": "on"}
+        ).data
+        assert features == {"feature_a": "off", "feature_b": "on"}
+
+        features = self.update(
+            self.ada, "api-features", {"feature_a": True, "feature_b": False}
+        ).data
+        assert features == {"feature_a": "on", "feature_b": "off"}
+
+    def test_errors(self):
+        response = self.update(self.ada, "api-features", {"foo": "bar"})
+        assert response.status_code == 400
+        assert response.data["errors"][0]["message"] == 'Invalid feature name "foo"'
+
+        response = self.update(self.ada, "api-features", {"feature_a": "nope"})
+        assert response.status_code == 400
+        assert response.data["errors"][0]["message"] == 'Invalid feature state "nope"'

--- a/manager/users/migrations/0002_flags.py
+++ b/manager/users/migrations/0002_flags.py
@@ -1,0 +1,62 @@
+from django.db import migrations, models
+
+def create_flags(apps, schema_editor):
+    Flag = apps.get_model('users', 'Flag')
+    Flag.objects.create(
+        name = "product_messages",
+        label = "Support messages",
+        note = "We use Intercom to provide...",
+        superusers = False,
+        default = "on",
+        settable = True
+    )
+    Flag.objects.create(
+        name = "product_tours",
+        label = "Product tours",
+        note = "We use UserFlow to provide...",
+        superusers = False,
+        default = "on",
+        settable = True
+    )
+    Flag.objects.create(
+        name = "product_analytics",
+        label = "Product analytics",
+        note = "We use PostHog to provide...",
+        superusers = False,
+        default = "on",
+        settable = True,
+    )
+    Flag.objects.create(
+        name = "crash_monitoring",
+        label = "Crash monitoring",
+        note = "We use Sentry to provide...",
+        superusers = False,
+        default = "on",
+        settable = True
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='flag',
+            name='label',
+            field=models.CharField(help_text='A label for the feature to display to users.', max_length=128),
+        ),
+        migrations.AddField(
+            model_name='flag',
+            name='default',
+            field=models.CharField(choices=[('on', 'On'), ('off', 'Off')], default='on', help_text='If the default is "on" then when the flag is active, the feature should be considered "off" and vice versa.', max_length=3),
+        ),
+        migrations.AddField(
+            model_name='flag',
+            name='settable',
+            field=models.BooleanField(default=False, help_text='User can turn this flag on/off for themselves.'),
+        ),
+        migrations.RunPython(create_flags),
+    ]

--- a/manager/users/migrations/0004_features.py
+++ b/manager/users/migrations/0004_features.py
@@ -5,7 +5,7 @@ def create_flags(apps, schema_editor):
     Flag.objects.create(
         name = "product_messages",
         label = "Support messages",
-        note = "We use Intercom to provide...",
+        note = "We use Intercom to provide in-app support via chat messages and notifications.",
         superusers = False,
         default = "on",
         settable = True
@@ -13,7 +13,7 @@ def create_flags(apps, schema_editor):
     Flag.objects.create(
         name = "product_tours",
         label = "Product tours",
-        note = "We use UserFlow to provide...",
+        note = "We use UserFlow to provide in-app product tours and onboarding checklists.",
         superusers = False,
         default = "on",
         settable = True
@@ -21,7 +21,7 @@ def create_flags(apps, schema_editor):
     Flag.objects.create(
         name = "product_analytics",
         label = "Product analytics",
-        note = "We use PostHog to provide...",
+        note = "We use PostHog to collect analytics on how users use our products.",
         superusers = False,
         default = "on",
         settable = True,
@@ -29,7 +29,7 @@ def create_flags(apps, schema_editor):
     Flag.objects.create(
         name = "crash_monitoring",
         label = "Crash monitoring",
-        note = "We use Sentry to provide...",
+        note = "We use Sentry for application monitoring and error reporting.",
         superusers = False,
         default = "on",
         settable = True
@@ -39,7 +39,7 @@ def create_flags(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('users', '0001_initial'),
+        ('users', '0003_auto_20201005_1924'),
     ]
 
     operations = [

--- a/manager/users/models.py
+++ b/manager/users/models.py
@@ -88,13 +88,39 @@ class Flag(AbstractUserFlag):
     """
     Custom feature flag model.
 
-    It is only possible to set this custom model once. In the future, fields may be
+    Adds fields to allow users to turn features on/off themselves.
+
+    In the future, fields may be
     added to allow flags to be set based on the account (in addition to, or instead
-    of only the user).
+    of, only the user).
     See https://waffle.readthedocs.io/en/stable/types/flag.html#custom-flag-models
     """
 
-    pass
+    label = models.CharField(
+        max_length=128, help_text="A label for the feature to display to users."
+    )
+
+    default = models.CharField(
+        max_length=3,
+        choices=[("on", "On"), ("off", "Off")],
+        default="on",
+        help_text='If the default is "on" then when the flag is active, '
+        'the feature should be considered "off" and vice versa.',
+    )
+
+    settable = models.BooleanField(
+        default=False, help_text="User can turn this flag on/off for themselves."
+    )
+
+    def is_active_for_user(self, user) -> bool:
+        """
+        Is the feature "on" for a user.
+
+        Changes the underlying behaviour of Waffle flags based on
+        the `default` field for the flag.
+        """
+        is_active = super().is_active_for_user(user)
+        return is_active if self.default == "off" else not is_active
 
 
 def generate_invite_key():

--- a/manager/users/templates/users/features.html
+++ b/manager/users/templates/users/features.html
@@ -1,0 +1,36 @@
+{% extends "base_centered.html" %}
+
+{% load i18n waffle_tags %}
+
+{% block title %}{% trans "Feature and privacy settings" %}{% endblock %}
+
+{% block layout_content %}
+<h1 class="title is-3">{% trans "Feature and privacy settings" %}</h1>
+
+<form hx-patch="{% url 'api-features' %}" hx-template="users/features.html" hx-select="form"
+      include-vals="{% for flag in flags %}{{ flag.name }}: document.querySelector('form [name={{ flag.name }}]').checked, {% endfor %}">
+  {% for flag in flags %}
+  <div class="level">
+    <h1 class="level-left title is-5">{{ flag.label }}</h1>
+    <span class="level-right has-text-right-tablet">
+      <input id="{{ flag.name }}" name="{{ flag.name }}" type="checkbox" class="toggle is-small is-inline"
+             {% flag flag.name %}checked{% endflag %}>
+      <label for="{{ flag.name }}">
+        <span class="is-sr-only">{{ flag.label }}</span>
+      </label>
+    </span>
+  </div>
+  <p>{{ flag.note }}</p>
+  <hr />
+  {% endfor %}
+  <button class="button is-primary" type="submit">
+    <span class="icon">
+      <i class="ri-refresh-line"></i>
+    </span>
+    <span>
+      {% trans "Update" %}
+    </span>
+  </button>
+</form>
+
+{% endblock %}

--- a/manager/users/ui/urls.py
+++ b/manager/users/ui/urls.py
@@ -5,6 +5,7 @@ from users.ui.views import (
     SigninView,
     SignoutView,
     SignupView,
+    features,
     invites_create,
     invites_list,
     redirect,
@@ -28,6 +29,7 @@ urlpatterns = [
             ]
         ),
     ),
+    path("features/", features, name="ui-users-features"),
     path("", include("allauth.urls")),
     # Redirect to the user's personal account
     # e.g. /me/settings -> username/settings

--- a/manager/users/ui/views.py
+++ b/manager/users/ui/views.py
@@ -9,7 +9,7 @@ from django.shortcuts import render, reverse
 
 from users.api.serializers import InviteSerializer
 from users.api.views.invites import InvitesViewSet
-from users.models import Invite
+from users.models import Flag, Invite
 
 logger = logging.getLogger(__name__)
 
@@ -161,6 +161,15 @@ signed_up_signal = (
     invitations.views.get_invitations_adapter().get_user_signed_up_signal()
 )
 signed_up_signal.connect(accept_invite_after_signup)
+
+
+@login_required
+def features(request: HttpRequest, *args, **kwargs) -> HttpResponse:
+    """
+    Feature and privacy settings.
+    """
+    flags = Flag.objects.filter(settable=True)
+    return render(request, "users/features.html", dict(flags=flags))
 
 
 @login_required


### PR DESCRIPTION
After discussing with @alex-ketch the need for allowing users to turn off things like product analytics, I realized that this could be fairly easily implemented using our existing `waffle`-based feature flags (which is good because that already does a things like caching, setting up the models etc).

Features, including those with privacy implications, can be set by users on a new `/me/features` page which is accessible from personal `/<account>/settings`:

![image](https://user-images.githubusercontent.com/1152336/88764967-ecd16900-d1c9-11ea-9a48-54db43cafd41.png)

- The `/me/features/` page has a description of the each feature and a toggle on/off. The `label` and `note` for these features flags are defined in `manager/users/migrations/0002_flags.py` but can be edited later via the admin (e.g. if we change external service provider for one of the features)

![image](https://user-images.githubusercontent.com/1152336/88765096-18ecea00-d1ca-11ea-819a-9ba5fd26dc8a.png)

- The `/stencila/admin/users/flag/` page allows adding and editing flags

![image](https://user-images.githubusercontent.com/1152336/88765602-d546b000-d1ca-11ea-8632-ffdee3af9c4b.png)

- Gettting a setting (`PATCH`) of flags is also available via the API e.g. 

```json
http --auth admin:admin :8000/api/features

HTTP/1.1 200 OK
Allow: GET, PATCH, HEAD, OPTIONS
Content-Length: 92
Content-Type: application/json
Date: Wed, 29 Jul 2020 06:40:32 GMT
Server: WSGIServer/0.2 CPython/3.7.7
Vary: Accept, Cookie
X-Content-Type-Options: nosniff
X-Frame-Options: DENY

{
    "crashMonitoring": "on", 
    "productAnalytics": "off", 
    "productMessages": "on", 
    "productTours": "on"
}
```

- There are some in-HTML comments e.g `<!-- crash_monitoring: on -->` that can be used for testing this is working during development although no unit-tests are yet written

@alex-ketch Could you take this over. Not a high priority, but when you have time / feel like a change. To do:

- [ ] Finalize `name`, `label` and `note` for each `Flag` in the migration
- [ ] Improve the `features.html` template.


