### PR TITLE
fix(Snapshots): Don't inject CSS variables as they're set by Designa

### DIFF
--- a/manager/projects/api/views/snapshots.py
+++ b/manager/projects/api/views/snapshots.py
@@ -156,13 +156,6 @@ class ProjectsSnapshotsViewSet(
 
         html = content
 
-        # Inject additional styles into head
-        # TODO: This may no longer be necessary
-        html = html.replace(
-            b"</head>",
-            b'<link rel="stylesheet" href="https://unpkg.com/@stencila/style-material/dist/index-material.css"></head>',
-        )
-
         # Inject execution toolbar
         source_url = reverse(
             "ui-projects-snapshots-retrieve",


### PR DESCRIPTION
With the upcoming fixes in Designa PR https://github.com/stencila/designa/pull/74, the following will no longer be necessary.
Can be currently tested be replacing the Designa UNPKG version in the Snapshot to point to the `@next` version.