### PR TITLE
Inject Executable Toolbar into Thema article context

### DIFF
--- a/manager/projects/api/views/snapshots.py
+++ b/manager/projects/api/views/snapshots.py
@@ -178,7 +178,7 @@ class ProjectsSnapshotsViewSet(
         """.format(
             source_url=source_url, session_provider_url=session_provider_url
         )
-        html = html.replace(b"<body>", b"<body>" + toolbar.encode())
+        html = html.replace(b'data-itemscope="root">', b'data-itemscope="root">' + toolbar.encode())
 
         response = HttpResponse(html)
 


### PR DESCRIPTION
This ensures that any CSS variables defined in the Thema theme are inherited by the Toolbar.
There's probably a less brittle way of finding the `data-itemscope="root` `article` element, but this works for now.
Please feel free to improve if you can @nokome, thanks!