### PR TITLE
fix(TS Client): Fix packaging of TypeScript client

### DIFF
--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -11,7 +11,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.prod.json",
     "prepare": "npm run build",
     "test": "jest"
   },

--- a/clients/typescript/tsconfig.prod.json
+++ b/clients/typescript/tsconfig.prod.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["dist", "node_modules", "__tests__"]
+}


### PR DESCRIPTION
Currently the TypeScript Hub Client's `main` entry file path doesn't resolve, causing errors when trying to use the package.
This is due to: `main": "./dist/index.js"`, however the published package file is at `dist/src/index`.

This PR fixes the the above issue, while at the same time avoiding the inclusion of test files in the published package.

---

**[Current package folder structure](https://unpkg.com/browse/@stencila/hub-client@3.41.0/dist/)**

![Screenshot 2020-10-06 at 14 43 03](https://user-images.githubusercontent.com/1646307/95246542-a6f4da80-07e2-11eb-8306-bf21db6575dc.png)
