### PR TITLE
API: Add more data to /users reponses

### DIFF
--- a/manager/users/api/serializers.py
+++ b/manager/users/api/serializers.py
@@ -16,9 +16,56 @@ class UserSerializer(serializers.ModelSerializer):
     Includes fields from the user's personal `Account`.
     """
 
+    display_name = serializers.SerializerMethodField()
+    location = serializers.SerializerMethodField()
+    image = serializers.SerializerMethodField()
+    website = serializers.SerializerMethodField()
+    public_email = serializers.SerializerMethodField()
+
+    def get_display_name(self, user):
+        """Get the display name of the user's personal account."""
+        return user.personal_account.display_name
+
+    def get_location(self, user):
+        """Get the location for the user's personal account."""
+        return user.personal_account.location
+
+    def get_image(self, user):
+        """Get the image for the user's personal account."""
+        request = self.context.get("request")
+        return dict(
+            [
+                (
+                    size,
+                    request.build_absolute_uri(
+                        getattr(user.personal_account.image, size)
+                    ),
+                )
+                for size in ("small", "medium", "large")
+            ]
+        )
+
+    def get_website(self, user):
+        """Get the website of the user's personal account."""
+        return user.personal_account.website
+
+    def get_public_email(self, user):
+        """Get the email address of the user's personal account."""
+        return user.personal_account.email
+
     class Meta:
         model = User
-        fields = ["id", "username", "first_name", "last_name"]
+        fields = [
+            "id",
+            "username",
+            "first_name",
+            "last_name",
+            "display_name",
+            "location",
+            "image",
+            "website",
+            "public_email",
+        ]
 
 
 class MeEmailAddressSerializer(serializers.ModelSerializer):

--- a/manager/users/api/views/users_tests.py
+++ b/manager/users/api/views/users_tests.py
@@ -12,8 +12,8 @@ class UserAPIViewsTests(DatabaseTestCase):
     def list_users(self, user, data={}):
         return self.list(user, "users", data=data)
 
-    def retrieve_user(self, user, pk: int):
-        return self.retrieve(user, "users", kwargs={"pk": pk})
+    def retrieve_user(self, user, user_: str):
+        return self.retrieve(user, "users", kwargs={"user": user_})
 
     def retrieve_me(self, user):
         return self.retrieve(user, "api-users-me")
@@ -34,9 +34,16 @@ class UserAPIViewsTests(DatabaseTestCase):
         assert users[0]["username"] == "cam"
 
     def test_retrieve_user(self):
-        response = self.retrieve_user(None, 2)
+        response = self.retrieve_user(None, "2")
         assert response.status_code == status.HTTP_200_OK
         assert response.data["username"] == User.objects.get(id=2).username
+
+        response = self.retrieve_user(None, "bob")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["username"] == "bob"
+
+        response = self.retrieve_user(None, "foo")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_retrieve_me(self):
         response = self.retrieve_me(None)


### PR DESCRIPTION
- allows a user to be retrieved by id or username
- adds personal account fields including image responses for `GET /users/{user}`
- adds additional fields including email addresses and linked external accounts to  `GET /users/me`

```json
{
    "dateJoined": "2020-10-06T02:10:43.359168Z", 
    "displayName": "Dr Anna Andersson", 
    "emailAddresses": [
        {
            "email": "anna@example.edu", 
            "primary": true, 
            "verified": true
        }, 
        {
            "email": "anna.andersson@example.com", 
            "primary": false, 
            "verified": false
        }
    ], 
    "firstName": "Anna", 
    "id": 8, 
    "image": {
        "large": "http://localhost:8000/local/media/__processed__/971/anna_WqQyX1C-a1a0071d4063.png", 
        "medium": "http://localhost:8000/local/media/__processed__/971/anna_WqQyX1C-5b678ba0c304.png", 
        "small": "http://localhost:8000/local/media/__processed__/971/anna_WqQyX1C-10c070f1761f.png"
    }, 
    "lastLogin": null, 
    "lastName": "Andersson", 
    "linkedAccounts": [], 
    "location": "Stockholm, Sweden", 
    "publicEmail": "anna@example.edu", 
    "username": "anna", 
    "website": "https://anna.example.edu/profile.html"
}
```

Closes #743