### PR TITLE
Attempt to handle WebComponent loading errors

### DIFF
--- a/manager/.gitignore
+++ b/manager/.gitignore
@@ -1,8 +1,7 @@
 /dev.sqlite3
 /manager/static/css/styles.css
 /manager/static/**/*.map
-/manager/static/js/index.js
-/manager/static/js/libs.js
+/manager/static/js/*.js
 /media
 /node_modules
 /snaps

--- a/manager/accounts/ui/views/content.py
+++ b/manager/accounts/ui/views/content.py
@@ -289,6 +289,13 @@ def index_html(
         ).encode(),
     )
 
+    html = html.replace(
+        b"<head>",
+        '<script src="{static}js/errorHandler.js"></script>'.format(
+            static=settings.STATIC_URL
+        ).encode(),
+    )
+
     # Pin the version of Stencila Components to avoid redirects to NPM which can slow
     # page load times down substantially
     html = html.replace(

--- a/manager/manager/static/js/src/errorHandler.js
+++ b/manager/manager/static/js/src/errorHandler.js
@@ -1,0 +1,55 @@
+// This is a simple attempt to handle errors which can occur when reading an executable article
+// The handler attempts to reload the article once, showing a message to the user if it continues to fail.
+
+const reloadSessionKey = "ERA_RELOAD_ATTEMPTED";
+let reloadAttempted;
+try {
+  reloadAttempted = window.sessionStorage.getItem(reloadSessionKey) === "true";
+} catch {
+  reloadAttempted = true;
+}
+
+// Attempt to reload the article once
+const tryAgain = () => {
+  window.sessionStorage.setItem(reloadSessionKey, "true");
+  window.location.reload();
+};
+
+// If the components fail to initialize after reloading the article, show an alert message to the reader
+let alertShown = false;
+const showAlert = () => {
+  window.sessionStorage.removeItem(reloadSessionKey);
+  if (!alertShown) {
+    alertShown = true;
+    alert(
+      "Unfortunately we are having problems loading the article. Please try visitng this page from different browser."
+    );
+
+    // throw a custom error to track in Sentry
+    throw new Error("Article initialization failed after reload");
+  }
+};
+
+// Multiple errors can occur on a single page load.
+// This prevents the error handling logic from running for each error.
+let errorHandled = false;
+
+const handleError = () => {
+  if (!errorHandled) {
+    errorHandled = true;
+    if (reloadAttempted) {
+      showAlert();
+    } else {
+      tryAgain();
+    }
+  }
+};
+
+window.addEventListener("unhandledrejection", (err) => {
+  if (
+    typeof err.reason.fileName === "string" &&
+    err.reason.fileName.includes("/dist/stencila-components/")
+  ) {
+    handleError();
+  }
+});

--- a/manager/rollup.config.js
+++ b/manager/rollup.config.js
@@ -36,4 +36,14 @@ export default [
     },
     plugins,
   },
+  {
+    input: "manager/static/js/src/errorHandler.js",
+    output: {
+      file: "manager/static/js/errorHandler.js",
+      sourcemap: true,
+      name: "ERAerrorHandler",
+      format: "iife",
+    },
+    plugins,
+  },
 ];


### PR DESCRIPTION
This is a simple attempt to handle errors which can occur when reading an executable article.
The handler attempts to reload the article once, showing a message to the user if it continues to fail.