### PR TITLE
Project gallery: Fix 3 column grid item size

### DIFF
--- a/manager/manager/static/sass/projects/index.scss
+++ b/manager/manager/static/sass/projects/index.scss
@@ -103,7 +103,7 @@ label[for="projects-search-input"] + .field {
     &:nth-child(2n + 1):not(:first-child),
     &:nth-child(2n + 2):not(:nth-child(2)),
     &:nth-child(3n + 3) {
-      width: 33%;
+      width: 33.333333%;
     }
   }
 }


### PR DESCRIPTION
Fixes math for the 3 column grid items to match the larger 2 column items.

![Screenshot 2020-12-11 at 21 34 38@2x](https://user-images.githubusercontent.com/1646307/101970515-df58d080-3bf8-11eb-83f2-3a9f040574b9.png)
