### PR TITLE
Fix link to Help documentation

### DIFF
--- a/manager/projects/templates/projects/_update_execution_form.html
+++ b/manager/projects/templates/projects/_update_execution_form.html
@@ -22,7 +22,7 @@ Form to update fileds related to how a project is executed.
       </span>
     </div>
     <span class="help">The container image to use as the execution environment for this project. See <a
-         href="https://help.stenci.la">help.stenci.la</a> for ways you can build and specify a custom image. If you
+         href="http://help.stenci.la">help.stenci.la</a> for ways you can build and specify a custom image. If you
       leave this
       blank a default image will be used.</span>
   </div>


### PR DESCRIPTION
Intercom help docs aren't served over HTTPS (right now?), and trying to visit the link shows a certificate error.
This "fixes" the issue.