### PR TITLE
fix(Pricing): Sort account plans for logged in users

### DIFF
--- a/manager/accounts/ui/views/accounts.py
+++ b/manager/accounts/ui/views/accounts.py
@@ -137,7 +137,7 @@ def plan(request: HttpRequest, *args, **kwargs) -> HttpResponse:
     viewset = AccountsViewSet.init("update_plan", request, args, kwargs)
     account = viewset.get_object()
     usage = AccountQuotas.usage(account)
-    tiers = AccountTier.objects.all()
+    tiers = AccountTier.objects.order_by("id").all()
     fields = AccountTier.fields()
     return render(
         request,


### PR DESCRIPTION
Related to https://github.com/stencila/hub/pull/880
The previous PR ensured plans were sorted for on `/pricing` view, but did not do so on the logged in user account view.