### PR TITLE
Trigger release when auto-updating ERA dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,22 @@
         "semanticCommitScope": "Deps"
       },
       {
+        "groupName": "ERA dependencies",
+        "paths": [
+          "package.json"
+        ],
+        "depTypeList": [
+          "devDependencies"
+        ],
+        "packagePatterns": [
+          "@stencila/thema",
+          "@stencila/components"
+        ],
+        "rangeStrategy": "pin",
+        "semanticCommitType": "fix",
+        "semanticCommitScope": "Deps"
+      },
+      {
         "groupName": "Python dev dependencies",
         "paths": [
           "requirements-dev.txt"


### PR DESCRIPTION
This PR updates the Renovate config to prefix `@stencila/thema` and `@stencila/component` package update commits with a `fix` keyword. This should trigger an automatic release cycle on the CI.