### PR TITLE
Add tooltip explaining differences between user roles

### DIFF
--- a/manager/accounts/templates/accounts/users/_account_role_help_tip.html
+++ b/manager/accounts/templates/accounts/users/_account_role_help_tip.html
@@ -7,10 +7,12 @@
   <div class="dropdown-menu">
     <div class="dropdown-content has-text-black">
       <p class="dropdown-item">
-        <strong>Member:</strong> can contribute to all Organization projects, create new projects, and delete projects they've created.
+        <strong>Member:</strong> can contribute to all Organization projects, create new projects, and delete projects
+        they've created.
       </p>
       <p class="dropdown-item">
-        <strong>Manager:</strong> can invite other users, manage teams, and configure Organization settings, in addition to the Member permissions.
+        <strong>Manager:</strong> can invite other users, manage teams, and configure Organization settings, in addition
+        to the Member permissions.
       </p>
       <p class="dropdown-item">
         <strong>Owner:</strong> can manage billing in addition to the Manager permissions.

--- a/manager/accounts/templates/accounts/users/_account_role_help_tip.html
+++ b/manager/accounts/templates/accounts/users/_account_role_help_tip.html
@@ -7,14 +7,13 @@
   <div class="dropdown-menu">
     <div class="dropdown-content has-text-black">
       <p class="dropdown-item">
-        <strong>Member:</strong> can create, update, and delete projects sources and files.
+        <strong>Member:</strong> can contribute to all Organization projects, create new projects, and delete projects they've created.
       </p>
       <p class="dropdown-item">
-        <strong>Manager:</strong> can create, update, and delete projects and teams in addition to the Member
-        permissions.
+        <strong>Manager:</strong> can invite other users, manage teams, and configure Organization settings, in addition to the Member permissions.
       </p>
       <p class="dropdown-item">
-        <strong> Owner:</strong> can delete projects, and configure paid plans in addition to the Manager permissions.
+        <strong>Owner:</strong> can manage billing in addition to the Manager permissions.
       </p>
     </div>
   </div>

--- a/manager/accounts/templates/accounts/users/_list.html
+++ b/manager/accounts/templates/accounts/users/_list.html
@@ -17,8 +17,9 @@
         </span>
       </div>
       <div class="level-right">
-        {# Do not allow managers or owners to change their role or remove themselves. Can cause UX confusion. #}
-        {% if role in "MANAGER,OWNER" and request.user != user %}
+        {# Do not allow managers or owners to change their role or remove themselves. #}
+        {# Do not allow managers to change role of, or remove, owners. #}
+        {% if role in "MANAGER,OWNER" and request.user != user and role|add:account_user.role != "MANAGEROWNER" %}
         <div class="field has-addons">
           <div class="control">
             <div class="select is-small-mobile">
@@ -69,9 +70,9 @@
           </div>
         </div>
         {% else %}
-        <p data-tooltip="{% trans "You cannot change your own role." %}"
+        <p data-tooltip="{% if request.user == user %}{% trans "You cannot change your own role." %}{% else %}{% trans "You can not change this users role." %}{% endif %}"
            class="has-tooltip-top has-tooltip-text-centered">
-          {{ role|title }}
+          {{ account_user.role|title }}
         </p>
         {% endif %}
       </div>

--- a/manager/accounts/templates/accounts/users/_list.html
+++ b/manager/accounts/templates/accounts/users/_list.html
@@ -32,8 +32,11 @@
                         {% if account_user.role == "MEMBER" %}selected{% endif %}>Member</option>
                 <option value="MANAGER"
                         {% if account_user.role == "MANAGER" %}selected{% endif %}>Manager</option>
+                {# Only allow owners to change up to owner role. #}
+                {% if role == "OWNER" %}
                 <option value="OWNER"
                         {% if account_user.role == "OWNER" %}selected{% endif %}>Owner</option>
+                {% endif %}
               </select>
             </div>
           </div>

--- a/manager/accounts/templates/accounts/users/update.html
+++ b/manager/accounts/templates/accounts/users/update.html
@@ -18,7 +18,10 @@
                 name="role">
           <option value="MEMBER">Member</option>
           <option value="MANAGER">Manager</option>
+          {# Only allow owners to add new owners . #}
+          {% if role in "OWNER" %}
           <option value="OWNER">Owner</option>
+          {% endif %}
         </select>
       </div>
     </div>

--- a/manager/accounts/templates/accounts/users/update.html
+++ b/manager/accounts/templates/accounts/users/update.html
@@ -7,31 +7,34 @@
 <h1 class="title is-sr-only-mobile">{% trans "Users" %}</h1>
 
 {% if role in "MANAGER,OWNER" %}
-<form class="field has-addons-tablet">
-  <div class="control is-expanded">
-    {% include "users/_search.html" %}
-  </div>
-  <div class="control is-expanded-mobile">
-    <div class="select">
-      <select id="accounts-users-add-role"
-              name="role">
-        <option value="MEMBER">Member</option>
-        <option value="MANAGER">Manager</option>
-        <option value="OWNER">Owner</option>
-      </select>
+<div class="is-flex is-flex-direction-row is-align-items-center">
+  <form class="field has-addons-tablet mb-0 is-flex-grow-1">
+    <div class="control is-expanded">
+      {% include "users/_search.html" %}
     </div>
-  </div>
-  <div class="control">
-    <button class="button is-primary is-outlined is-fullwidth-mobile"
-            hx-post="{% url 'api-accounts-users-list' account.id %}"
-            hx-include="#user-search input[name=id], #accounts-users-add-role"
-            hx-template="accounts/users/_list.html"
-            hx-target="#accounts-users-list">
-      <span class="icon"><i class="ri-add-line"></i></span>
-      <span>Add</span>
-    </button>
-  </div>
-</form>
+    <div class="control is-expanded-mobile">
+      <div class="select">
+        <select id="accounts-users-add-role"
+                name="role">
+          <option value="MEMBER">Member</option>
+          <option value="MANAGER">Manager</option>
+          <option value="OWNER">Owner</option>
+        </select>
+      </div>
+    </div>
+    <div class="control">
+      <button class="button is-primary is-outlined is-fullwidth-mobile"
+              hx-post="{% url 'api-accounts-users-list' account.id %}"
+              hx-include="#user-search input[name=id], #accounts-users-add-role"
+              hx-template="accounts/users/_list.html"
+              hx-target="#accounts-users-list">
+        <span class="icon"><i class="ri-add-line"></i></span>
+        <span>Add</span>
+      </button>
+    </div>
+  </form>
+  {% include "_user_role_help_tip.html" %}
+</div>
 <p class="help">
   Can't find who you are looking for?
   <a

--- a/manager/accounts/templates/accounts/users/update.html
+++ b/manager/accounts/templates/accounts/users/update.html
@@ -33,7 +33,7 @@
       </button>
     </div>
   </form>
-  {% include "_user_role_help_tip.html" %}
+  {% include "./_account_role_help_tip.html" %}
 </div>
 <p class="help">
   Can't find who you are looking for?

--- a/manager/manager/api/helpers.py
+++ b/manager/manager/api/helpers.py
@@ -211,7 +211,9 @@ class HtmxDestroyMixin(HtmxMixin):  # noqa: D101
 
         serializer_class = self.get_serializer_class()
         if serializer_class:
-            serializer = serializer_class(instance, data=request.data)
+            serializer = serializer_class(
+                instance, data=request.data, context=self.get_serializer_context()
+            )
         else:
             serializer = None
 

--- a/manager/manager/static/sass/styles.scss
+++ b/manager/manager/static/sass/styles.scss
@@ -815,6 +815,10 @@ input[type="checkbox"].toggle {
   cursor: url("../img/close-circle-line.svg"), pointer;
 }
 
+.cursor-help {
+  cursor: help;
+}
+
 .is-vcentered {
   vertical-align: middle;
 }

--- a/manager/manager/templates/_user_role_help_tip.html
+++ b/manager/manager/templates/_user_role_help_tip.html
@@ -1,0 +1,21 @@
+{% comment %} Render an icon representing the type of job {% endcomment %}
+
+<div class="icon is-vcentered has-text-grey dropdown is-hoverable cursor-help">
+  <div class="dropdown-trigger">
+    <i class="ri-question-line"></i>
+  </div>
+  <div class="dropdown-menu">
+    <div class="dropdown-content has-text-black">
+      <p class="dropdown-item">
+        <strong>Member:</strong> can create, update, and delete projects sources and files.
+      </p>
+      <p class="dropdown-item">
+        <strong>Manager:</strong> can create, update, and delete projects and teams in addition to the Member
+        permissions.
+      </p>
+      <p class="dropdown-item">
+        <strong> Owner:</strong> can delete projects, and configure paid plans in addition to the Manager permissions.
+      </p>
+    </div>
+  </div>
+</div>

--- a/manager/projects/models/projects.py
+++ b/manager/projects/models/projects.py
@@ -564,8 +564,8 @@ class ProjectRole(EnumChoice):
         return {
             cls.READER.name: "Can view project, but not make edits or share with others.",
             cls.REVIEWER.name: "Can view project files and leave comments, but not edit project or share with others.",
-            cls.EDITOR.name: "Can edit project files and leave comments, but not share with other.",
-            cls.AUTHOR.name: "Can edit project files and leave comments, but not share with other.",
+            cls.EDITOR.name: "Can edit project files and leave comments, but not share with others.",
+            cls.AUTHOR.name: "Can edit project files and leave comments, but not share with others.",
             cls.MANAGER.name: "Can edit project files, settings, and share with others.",
             cls.OWNER.name: "Can edit project files, settings, share with others, as well as delete a project",
         }[role.name]

--- a/manager/projects/templates/projects/_agents_list.html
+++ b/manager/projects/templates/projects/_agents_list.html
@@ -35,6 +35,8 @@
                       hx-template="projects/_agents_list.html"
                       hx-target="#projects-agents-list"
                       name="role">
+                <option value="READER"
+                        {% if agent.role == "READER" %}selected{% endif %}>Reader</option>
                 <option value="AUTHOR"
                         {% if agent.role == "AUTHOR" %}selected{% endif %}>Author</option>
                 <option value="MANAGER"

--- a/manager/projects/templates/projects/_collaborator_role_help_tip.html
+++ b/manager/projects/templates/projects/_collaborator_role_help_tip.html
@@ -1,0 +1,23 @@
+{% comment %} Render an icon representing the type of job {% endcomment %}
+
+<div class="icon is-vcentered has-text-grey dropdown is-hoverable cursor-help">
+  <div class="dropdown-trigger">
+    <i class="ri-question-line"></i>
+  </div>
+  <div class="dropdown-menu">
+    <div class="dropdown-content has-text-black">
+      <p class="dropdown-item">
+        <strong>Reader:</strong> Can view the project, but not make edits or share with others.
+      </p>
+      <p class="dropdown-item">
+        <strong>Author:</strong> Can edit project files, but not share with others.
+      </p>
+      <p class="dropdown-item">
+        <strong>Manager:</strong> Can edit project files, settings, and share with others.
+      </p>
+      <p class="dropdown-item">
+        <strong>Owner:</strong> Can edit project files, settings, share with others, as well as delete the project.
+      </p>
+    </div>
+  </div>
+</div>

--- a/manager/projects/templates/projects/sharing.html
+++ b/manager/projects/templates/projects/sharing.html
@@ -45,7 +45,7 @@
       </button>
     </div>
   </form>
-  {% include "_user_role_help_tip.html" %}
+  {% include "./_collaborator_role_help_tip.html" %}
 </div>
 <p class="help">
   Can't find who you are looking for?

--- a/manager/projects/templates/projects/sharing.html
+++ b/manager/projects/templates/projects/sharing.html
@@ -28,6 +28,7 @@
       <div class="select">
         <select id="projects-agents-add-role"
                 name="role">
+          <option value="READER">Reader</option>
           <option value="AUTHOR">Author</option>
           <option value="MANAGER">Manager</option>
           <option value="OWNER">Owner</option>

--- a/manager/projects/templates/projects/sharing.html
+++ b/manager/projects/templates/projects/sharing.html
@@ -13,37 +13,40 @@
 <h2 class="title is-4">{% trans "Collaborators" %}</h2>
 
 {% if project.role in "MANAGER,OWNER" %}
-<form class="field has-addons-tablet">
-  <input type="hidden"
-         name="type"
-         value="user">
-  <div class="control is-expanded">
-    {% include "users/_search.html" with id_name="agent" %}
-  </div>
-
-  <div class="control is-expanded-mobile">
-    <label class="label is-sr-only"
-           for="projects-agents-add-role">{% trans "User role" %}</label>
-    <div class="select">
-      <select id="projects-agents-add-role"
-              name="role">
-        <option value="AUTHOR">Author</option>
-        <option value="MANAGER">Manager</option>
-        <option value="OWNER">Owner</option>
-      </select>
+<div class="is-flex is-flex-direction-row is-align-items-center">
+  <form class="field has-addons-tablet mb-0 is-flex-grow-1">
+    <input type="hidden"
+           name="type"
+           value="user">
+    <div class="control is-expanded">
+      {% include "users/_search.html" with id_name="agent" %}
     </div>
-  </div>
-  <div class="control">
-    <button class="button is-primary is-outlined is-fullwidth-mobile"
-            hx-post="{% url 'api-projects-agents-list' project.id %}"
-            hx-include="#projects-agents-add-type, #user-search-result-id, #projects-agents-add-role"
-            hx-template="projects/_agents_list.html"
-            hx-target="#projects-agents-list">
-      <span class="icon"><i class="ri-add-line"></i></span>
-      <span>Add</span>
-    </button>
-  </div>
-</form>
+
+    <div class="control is-expanded-mobile">
+      <label class="label is-sr-only"
+             for="projects-agents-add-role">{% trans "User role" %}</label>
+      <div class="select">
+        <select id="projects-agents-add-role"
+                name="role">
+          <option value="AUTHOR">Author</option>
+          <option value="MANAGER">Manager</option>
+          <option value="OWNER">Owner</option>
+        </select>
+      </div>
+    </div>
+    <div class="control">
+      <button class="button is-primary is-outlined is-fullwidth-mobile"
+              hx-post="{% url 'api-projects-agents-list' project.id %}"
+              hx-include="#projects-agents-add-type, #user-search-result-id, #projects-agents-add-role"
+              hx-template="projects/_agents_list.html"
+              hx-target="#projects-agents-list">
+        <span class="icon"><i class="ri-add-line"></i></span>
+        <span>Add</span>
+      </button>
+    </div>
+  </form>
+  {% include "_user_role_help_tip.html" %}
+</div>
 <p class="help">
   Can't find who you are looking for?
   <a

--- a/manager/projects/templates/projects/update.html
+++ b/manager/projects/templates/projects/update.html
@@ -26,9 +26,12 @@
 <p class="subtitle is-6">{% trans "Settings affecting how content is served for this project." %}</p>
 {% include "./_update_content_form.html" %}
 
+{% if project.role == "OWNER" %}
 <hr />
 
 <h2 class="title is-4 is-outlined">{% trans "Delete" %}</h2>
 {% include "./_destroy_form.html" with serializer=destroy_serializer %}
+
+{% endif %}
 
 {% endblock %}


### PR DESCRIPTION
Close #709 

I was debating whether to place the tooltip closer to the current area of focus (the input fields), or move it to the section title (above the form, next to the `Collaborators` text). There is minor visual offset happening when the icon is placed next to the input field, however I felt that it would be the most helpful and discoverable there when a user is trying to add members.
Do you have any thoughts @nokome? Would also appreciate if you could look over and verify the role differences in the help text.
Thanks!

![Screenshot 2021-02-12 at 14 27 12](https://user-images.githubusercontent.com/1646307/107813451-6d0e8480-6d3e-11eb-93a7-39bdfd81f5b9.png)

**Mobile**

![Screenshot 2021-02-12 at 14 08 49](https://user-images.githubusercontent.com/1646307/107813472-74359280-6d3e-11eb-8488-ff6d946764bd.png)

![Screenshot 2021-02-12 at 14 08 36](https://user-images.githubusercontent.com/1646307/107813488-7992dd00-6d3e-11eb-96c4-8caa29209f37.png)
