### PR TITLE
Fix job creator link & nested sub-job list styling

### DIFF
--- a/manager/manager/static/sass/projects/index.scss
+++ b/manager/manager/static/sass/projects/index.scss
@@ -251,7 +251,6 @@ label[for="projects-search-input"] + .field {
 }
 
 .job-list__sub-jobs {
-  border-left: 2px solid $grey-lighter;
   position: relative;
 
   &::before {
@@ -286,6 +285,18 @@ label[for="projects-search-input"] + .field {
     font-weight: bold;
     line-height: 1;
     z-index: 10;
+  }
+
+  .job-list__sub-jobs {
+    margin-left: $column-gap / 2;
+
+    @media screen and (min-width: $tablet) {
+      margin-left: $column-gap;
+    }
+  }
+
+  & li > .columns {
+    border-left: 2px solid #aeb8c3;
   }
 
   .column {

--- a/manager/projects/templates/projects/jobs/_job_item.html
+++ b/manager/projects/templates/projects/jobs/_job_item.html
@@ -20,7 +20,7 @@
         {% with creator=job.creator %}
         {% if creator %}
         {% if creator.personal_account.image.medium %}
-        <a href="{% url 'ui-accounts-retrieve' user.username %}">
+        <a href="{% url 'ui-accounts-retrieve' job.creator.username %}">
           <span class="icon is-vcentered pr-1">
             <img src="{{ job.creator.personal_account.image.medium }}"
                  role="presentation"></img>


### PR DESCRIPTION
- Fix link to Job creator profile, previously it would point to the currently logged in user's profile instead of the account which triggered the job
- Fix styling of nested sub-jobs list to avoid a double left-border