### PR TITLE
Mention 3rd party cookie requirement for adding Google sources

### DIFF
--- a/manager/manager/static/sass/styles.scss
+++ b/manager/manager/static/sass/styles.scss
@@ -602,6 +602,23 @@ body {
   }
 }
 
+.has-text-inherit {
+  color: inherit;
+}
+
+a.has-text-inherit {
+  &:link,
+  &:visited {
+    color: inherit;
+    text-decoration: underline;
+  }
+
+  &:hover,
+  &:active {
+    color: $link;
+  }
+}
+
 .title.secondary {
   color: $grey-dark;
   margin-bottom: 0;
@@ -823,6 +840,10 @@ input[type="checkbox"].toggle {
   vertical-align: middle;
 }
 
+.is-vtop {
+  vertical-align: text-top;
+}
+
 .has-text-nowrap {
   white-space: nowrap;
 }
@@ -869,7 +890,7 @@ a.list-menu--item {
 .icon > i {
   height: 1em;
   width: 1em;
-  
+
   &::before {
     display: block;
     line-height: 1;

--- a/manager/projects/templates/projects/sources/_create_googledrive_picker.html
+++ b/manager/projects/templates/projects/sources/_create_googledrive_picker.html
@@ -146,8 +146,19 @@ A "file picker" for Google Drive. See
 {% endfor %}
 {% endif %}
 
-<p class="help mb-4">
+
+<p class="help mb-0">
   The Google id for the file or folder e.g. 1iNeKTbnIcW_92Hjc8qxMkrW2jPrvwjHuANju2hkaYkA.
+</p>
+
+<p class="help mt-0 mb-4 has-text-warning-dark">
+  <span class="icon is-small">
+    <i class="ri-information-line"></i>
+  </span>
+  <span class="is-vtop leading-none">If you encounter errors trying to select a file, please <a
+       href="https://developers.google.com/identity/sign-in/web/troubleshooting#third-party_cookies_and_data_blocked"
+       rel="nofollow"
+       class="has-text-inherit">enable third-party cookies</a> in your browser.</span>
 </p>
 
 {% endwith %}


### PR DESCRIPTION
We noticed that the File Picker would cause `400` errors if the browser did not have 3rd party cookies enabled.
The link leads to [Google known issues document](https://developers.google.com/identity/sign-in/web/troubleshooting#third-party_cookies_and_data_blocked) which mentions possibility of making an exception for `accounts.google.com` domain.

Do you think it's necessary to create a standalone help article of our own at this time @nokome?

<img width="494" alt="Screenshot 2021-02-24 at 10 51 19@2x" src="https://user-images.githubusercontent.com/1646307/109027499-d8394e80-768e-11eb-94d8-1c19d3a9567d.png">
