### PR TITLE
Misc UX and quality of life refinements

### DIFF
--- a/manager/manager/templates/base.html
+++ b/manager/manager/templates/base.html
@@ -253,6 +253,47 @@
               </div>
             </div>
             {% else %}
+            <div class="navbar-item px-0 {% if user.is_authenticated %}has-dropdown{% endif%}">
+              <a class="navbar-link {% if user.is_anonymous %}is-arrowless{% endif%}"
+                 href="http://help.stenci.la/"
+                 target="_blank"
+                 rel="noopener">
+                <span class="icon">
+                  <i class="ri-lifebuoy-line"
+                     aria-hidden="true"></i>
+                </span>
+                <span>{% trans "Help" %}</span>
+              </a>
+
+              <div class="navbar-dropdown">
+                {% if USERFLOW_TOKEN and user.is_authenticated %}
+                <a class="navbar-item has-text-weight-bold"
+                   href="#"
+                   onclick="userflow.start('382d5643-1be7-4799-88e3-0410616f172d')">
+                  <span class="icon">
+                    <i class="ri-magic-line"
+                       aria-hidden="true"></i>
+                  </span>
+                  <span>
+                    {% trans "In-app tutorials" %}
+                  </span>
+                </a>
+                {% endif %}
+                <a class="navbar-item has-text-weight-bold"
+                   href="http://help.stenci.la/"
+                   target="_blank"
+                   rel="noopener">
+                  <span class="icon">
+                    <i class="ri-book-read-line"
+                       aria-hidden="true"></i>
+                  </span>
+                  <span>
+                    {% trans "Knowledge centre" %}
+                  </span>
+                </a>
+              </div>
+            </div>
+
             <div class="navbar-item has-dropdown">
               <a class="navbar-link"
                  href="{% url 'ui-accounts-retrieve' user.username %}"
@@ -305,17 +346,6 @@
                   <span>{% trans "Admin" %}</span>
                 </a>
                 {% endif %}
-
-                <a class="navbar-item has-text-weight-bold"
-                   href="http://help.stenci.la/"
-                   target="_blank"
-                   rel="noopener">
-                  <span class="icon">
-                    <i class="ri-lifebuoy-line"
-                       aria-hidden="true"></i>
-                  </span>
-                  <span>{% trans "Help" %}</span>
-                </a>
 
                 <a class="navbar-item has-text-weight-bold"
                    href="{% url 'ui-users-signout' %}">
@@ -375,7 +405,7 @@
         <div class="column is-full has-text-centered">
           <a href="http://help.stenci.la/en"
              target="_blank"
-             rel="noopener">{% trans "Docs" %}</a>
+             rel="noopener">{% trans "Documentation" %}</a>
           <a href="{% url 'api-docs' %}"
              target="_blank"
              rel="noopener">API</a>

--- a/manager/manager/templates/base.html
+++ b/manager/manager/templates/base.html
@@ -85,7 +85,7 @@
       <div class="container">
         <div class="navbar-brand">
           <a class="navbar-item navbar-logo"
-             href="https://stenci.la">
+             href="{% if user.is_authenticated %}/{% else%}https://stenci.la{% endif%}">
             {% if user.is_anonymous %}
             <img title="Homepage"
                  src="{% static 'img/stencilaLogo.svg' %}"

--- a/manager/manager/templates/base.html
+++ b/manager/manager/templates/base.html
@@ -39,7 +39,6 @@
           integrity="sha384-O8HdAJg1h8RARFowXd2J/r5fIWuinSBtjhwQoPesfVILeXzGpJxvyY/77OaPPXUo"
           crossorigin="anonymous">
   </script>
-  </script>
   <script>
     Sentry.init({
       dsn: '{{ SENTRY_DSN }}',

--- a/manager/projects/templates/projects/jobs/_progress_buttons.html
+++ b/manager/projects/templates/projects/jobs/_progress_buttons.html
@@ -7,10 +7,15 @@
      hx-swap="outerHTML"
      {% endif %}>
   <progress class="progress is-vcentered is-primary"
-            value="{{ job.runtime_seconds|default:0 }}"
+            value="{% if job.status == "SUCCESS" or job.error %}{{ runtime_expected|default:60 }}{% else %}{{ job.runtime_seconds|default:0 }}{% endif %}"
             max="{{ runtime_expected|default:60 }}">
     {{ job.runtime_formatted }}
   </progress>
+  {% if job.status == "SUCCESS" %}
+  <p class="notification is-success is-expanded">
+    {% trans "File converted successfully" %}
+  </p>
+  {% endif %}
   {% if job.error %}
   <p class="notification is-danger is-expanded">
     {{ job.error.message }}
@@ -36,36 +41,13 @@
       </span>
       {% endif %}
     </button>
-    {% else %}
-    <a class="button is-primary is-fullwidth-mobile"
-       href="{{ next }}">
-      {% if job.status == "SUCCESS" %}
-      <span class="icon">
-        <i class="ri-check-line"></i>
-      </span>
-      <span>
-        {% blocktrans %}Finished{% endblocktrans %}
-      </span>
-      {% elif job.error %}
-      <span class="icon">
-        <i class="ri-error-warning-line"></i>
-      </span>
-      <span>
-        {% blocktrans %}Errored{% endblocktrans %}
-      </span>
-      {% endif %}
-    </a>
     {% endif %}
     <a href="{{ prev }}"
-       class="button is-outlined is-fullwidth-mobile">
+       class="button is-fullwidth-mobile {% if job.status == "SUCCESS" or job.error %}is-default is-primary{% else %}is-outlined{% endif %}">
       <span class="icon">
         <i class="ri-arrow-go-back-line"></i>
       </span>
-      {% if job.is_active %}
-      <span>{% trans "Cancel" %}</span>
-      {% else %}
-      <span>{% trans "Close" %}</span>
-      {% endif %}
+      <span>{% trans "Go Back" %}</span>
     </a>
   </div>
 </div>


### PR DESCRIPTION
- Updates the header logo link to direct signed in users to the Hub root page, and anonymous users to the marketing site. This helps reduce confusion for signed in users as on the marketing site we don't share the signed-in state, and all users are shown the `sign in`/`sign -up` buttons
- To make the help resources more discoverable, signed in users will now see a dedicated "Help" item in the nav bar. If the deployment has a Userflow key, we also show a `In app guides` link which triggers the `Get started` checklist.
![Screenshot 2021-03-10 at 14 31 26](https://user-images.githubusercontent.com/1646307/110686347-53c9ee00-81ad-11eb-81c5-23fd0562a10d.png)

- File conversion progress bar will now always fill to 100% on job completion/error. I've also removed the dual actions for "Finished" + "Back" and only show a single "Go back" button when the job is finished.

https://user-images.githubusercontent.com/1646307/110685986-daca9680-81ac-11eb-8695-2b2ebea4e7ce.mp4


