### PR TITLE
fix(Manager): Fix users not being sorted alphabetically

### DIFF
--- a/manager/accounts/api/views.py
+++ b/manager/accounts/api/views.py
@@ -36,7 +36,7 @@ from manager.api.helpers import (
 )
 from users.api.serializers import UserIdentifierSerializer
 from users.models import User
-
+from users.models import get_name
 
 def get_account(
     identifier: str, user: User, roles: Optional[List[AccountRole]] = None,
@@ -348,7 +348,11 @@ class AccountsUsersViewSet(
         """
         if account is None:
             account = self.get_account()
-        return AccountUser.objects.filter(account=account)
+        
+        return sorted(
+            AccountUser.objects.filter(account=account).select_related('user__personal_account'),
+            key=lambda account_user: get_name(account_user.user),
+        )
 
     def get_object(self, account=None):
         """

--- a/manager/accounts/api/views.py
+++ b/manager/accounts/api/views.py
@@ -35,8 +35,8 @@ from manager.api.helpers import (
     filter_from_ident,
 )
 from users.api.serializers import UserIdentifierSerializer
-from users.models import User
-from users.models import get_name
+from users.models import User, get_name
+
 
 def get_account(
     identifier: str, user: User, roles: Optional[List[AccountRole]] = None,
@@ -348,9 +348,11 @@ class AccountsUsersViewSet(
         """
         if account is None:
             account = self.get_account()
-        
+
         return sorted(
-            AccountUser.objects.filter(account=account).select_related('user__personal_account'),
+            AccountUser.objects.filter(account=account).select_related(
+                "user__personal_account"
+            ),
             key=lambda account_user: get_name(account_user.user),
         )
 

--- a/manager/accounts/templates/accounts/users/_list.html
+++ b/manager/accounts/templates/accounts/users/_list.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load stencila i18n %}
 
 <ul id="accounts-users-list">
   {% for account_user in account_users %}
@@ -12,7 +12,7 @@
         </span>
         <span class="has-text-bold">
           <a href="{% url 'ui-accounts-retrieve' user.username %}">
-            {{ user.get_full_name|default:user.username }}
+            {{ user|get_name }}
           </a>
         </span>
       </div>

--- a/manager/manager/templatetags/stencila.py
+++ b/manager/manager/templatetags/stencila.py
@@ -17,6 +17,7 @@ from rest_framework import serializers
 from rest_framework.utils.field_mapping import ClassLookupDict
 
 from projects.models.files import FileFormat, FileFormats
+from users.models import get_name as user_get_name
 
 register = template.Library()
 
@@ -219,6 +220,14 @@ def tier_count(count):
         return "Unlimited"
     else:
         return count
+
+
+@register.filter
+def get_name(user):
+    """
+    Get the best name to display for a user.
+    """
+    return user_get_name(user)
 
 
 @register.tag


### PR DESCRIPTION
Comments:
- the user name "Daniel" in the user list seemed to not sort correctly (believe it could be an issue with how it is saved? all others seemed to order correctly) 
- when I create a new test user it seems to also order them at the bottom (also could be related to how the data is saved for new accounts?) 
- Overall seems to sort as required 